### PR TITLE
Support Token V4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,9 @@ let package = Package(
         .package(url: "https://github.com/mkrd/Swift-BigInt.git",
                  from: "2.0.0"),
         .package(url: "https://github.com/pengpengliu/BIP39.git",
-                 from: "1.0.0")
+                 from: "1.0.0"),
+        .package(url: "https://github.com/myfreeweb/SwiftCBOR.git",
+                 from: "0.4.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -36,7 +38,8 @@ let package = Package(
                 .product(name: "secp256k1", package: "secp256k1.swift"),
                 .product(name: "BIP32", package: "BIP32"),
                 .product(name: "BigNumber", package: "Swift-BigInt"),
-                .product(name: "BIP39", package: "BIP39")
+                .product(name: "BIP39", package: "BIP39"),
+                .product(name: "SwiftCBOR", package: "SwiftCBOR")
             ]),
 
         .testTarget(

--- a/Sources/cashu-swift/Error.swift
+++ b/Sources/cashu-swift/Error.swift
@@ -18,7 +18,7 @@ public enum CashuError: Swift.Error {
     case transactionUnbalanced // 11002
     case invalidToken
     case tokenEncoding
-    case tokenDecoding
+    case tokenDecoding(String)
     case unsupportedToken(String)
     case inputError(String)
     case insufficientInputs(String)

--- a/Sources/cashu-swift/Protocols.swift
+++ b/Sources/cashu-swift/Protocols.swift
@@ -15,7 +15,7 @@ public protocol MintRepresenting {
     init(url:URL, keysets:[CashuSwift.Keyset])
 }
 
-public protocol ProofRepresenting {
+public protocol ProofRepresenting/*: Codable, Equatable*/ {
     var keysetID:String { get }
     var C:String { get }
     var secret:String { get }

--- a/Sources/cashu-swift/Token.swift
+++ b/Sources/cashu-swift/Token.swift
@@ -19,7 +19,7 @@ extension CashuSwift {
         public let memo: String?
         
         ///Dictionary containing the mint URL absolute string as key and a list of `ProofRepresenting` as the proofs for this token.
-        public let proofs: Dictionary<String, [ProofRepresenting]>
+        public let proofsByMint: Dictionary<String, [ProofRepresenting]>
         
         public func serialize(to version: CashuSwift.TokenVersion = .V3) throws -> String {
             switch version {
@@ -33,7 +33,7 @@ extension CashuSwift {
         init(proofs: [String: [ProofRepresenting]],
              unit: String,
              memo: String? = nil) {
-            self.proofs = proofs
+            self.proofsByMint = proofs
             self.unit = unit
             self.memo = memo
         }
@@ -41,7 +41,7 @@ extension CashuSwift {
         init(token:TokenV3) throws {
             self.memo = token.memo
             self.unit = token.unit ?? "sat" // technically not ideal, there might be non-sat V3 tokens
-            self.proofs = Dictionary(uniqueKeysWithValues: token.token.map { ($0.mint, $0.proofs) })
+            self.proofsByMint = Dictionary(uniqueKeysWithValues: token.token.map { ($0.mint, $0.proofs) })
         }
         
         init(token:TokenV4) throws {
@@ -63,12 +63,12 @@ extension CashuSwift {
             
             proofsPerMint[token.mint] = ps
             
-            self.proofs = proofsPerMint
+            self.proofsByMint = proofsPerMint
         }
         
         private func makeV3() throws -> TokenV3 {
             
-            let proofsContainers = proofs.map { (mintURLString, proofList) in
+            let proofsContainers = proofsByMint.map { (mintURLString, proofList) in
                 ProofContainer(mint: mintURLString,
                                proofs: proofList.map({ p in
                     Proof(keysetID: p.keysetID,
@@ -85,11 +85,11 @@ extension CashuSwift {
         }
         
         private func makeV4() throws -> TokenV4 {
-            guard proofs.count < 2 else {
+            guard proofsByMint.count < 2 else {
                 throw CashuError.tokenEncoding
             }
             
-            guard let (mintURLstring, proofList) = proofs.first else {
+            guard let (mintURLstring, proofList) = proofsByMint.first else {
                 throw CashuError.tokenEncoding
             }
             

--- a/Sources/cashu-swift/Token.swift
+++ b/Sources/cashu-swift/Token.swift
@@ -32,7 +32,7 @@ extension CashuSwift {
             }
         }
         
-        init(proofs: [String: [any ProofRepresenting]],
+        public init(proofs: [String: [any ProofRepresenting]],
              unit: String,
              memo: String? = nil) {
             self.proofsByMint = proofs

--- a/Sources/cashu-swift/Token.swift
+++ b/Sources/cashu-swift/Token.swift
@@ -1,162 +1,132 @@
 //
 //  File.swift
-//  
+//  CashuSwift
 //
-//  Created by zm on 07.05.24.
+//  Created by zm on 29.11.24.
 //
 
 import Foundation
-import OSLog
 
-fileprivate var logger = Logger(subsystem: "cashu-swift", category: "Token")
 
 extension CashuSwift {
-    public enum TokenVersion:Codable {
-        case V3
-        case V4
-    }
-
-    public class Token:Codable, Equatable {
-        public static func == (lhs: Token, rhs: Token) -> Bool {
-            lhs.token == rhs.token && lhs.memo == rhs.memo && lhs.unit == rhs.unit
-        }
+    
+    ///General purpose struct for storing version agnostic token information that can be transformed into `TokenV3` or `TokenV4` for serialization.
+    public struct Token {
+        ///Unit string like "sat". "eur" or "usd"
+        public let unit: String
         
-        public let token:[ProofContainer]
-        public let memo:String?
-        public let unit:String?
+        ///Optional memo for the recipient
+        public let memo: String?
         
-        public init(token: [ProofContainer],
-             memo: String? = nil,
-             unit:String? = nil) {
-            self.token = token
-            self.memo = memo
-            self.unit = unit
-        }
+        ///Dictionary containing the mint URL absolute string as key and a list of `ProofRepresenting` as the proofs for this token.
+        public let proofs: Dictionary<String, [ProofRepresenting]>
         
-        enum CodingKeys:String, CodingKey {
-            case token
-            case memo
-            case unit
-        }
-        
-        public func serialize(_ toVersion:TokenVersion = .V4) throws -> String {
-            switch toVersion {
+        public func serialize(to version: CashuSwift.TokenVersion = .V3) throws -> String {
+            switch version {
             case .V3:
-                try encodeV3(token: self)
+                return try self.makeV3().serialize()
             case .V4:
-                throw CashuError.unsupportedToken("V4 tokens are not supported yet, but will be soon\u{2122}.")
+                return try self.makeV4().serialize()
             }
         }
         
-        private func encodeV3(token:Token) throws -> String {
-            let jsonData = try JSONEncoder().encode(self)
-            let jsonString = String(data: jsonData, encoding: .utf8)!
-            let safeString = try jsonString.encodeBase64UrlSafe()
-            return "cashuA" + safeString
-        }
-        
-        private func encodeV4cbor(token:Token) throws -> String {
-            throw CashuError.unsupportedToken("V4 tokens are not supported yet, but will be soon\u{2122}.")
-        }
-        
-        static func decodeV3(tokenString:String) throws -> Token {
-            let noPrefix = String(tokenString.dropFirst(6))
-            guard let jsonString = noPrefix.decodeBase64UrlSafe() else {
-                throw CashuError.invalidToken
-            }
-            let jsonData = jsonString.data(using: .utf8)!
-            do {
-                let token:Token = try JSONDecoder().decode(Token.self, from: jsonData)
-                return token
-            } catch {
-                logger.warning("Could not deserialize token. error: \(String(describing: error))")
-                throw CashuError.invalidToken
-            }
-        }
-        
-        static func decodeV4(tokenString:String) throws -> Token {
-            throw CashuError.unsupportedToken("V4 tokens are not supported yet, but will be soon\u{2122}.")
-        }
-        
-        func prettyJSON() -> String {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            do {
-                let data = try encoder.encode(self)
-                return String(data: data, encoding: .utf8) ?? ""
-            } catch {
-                return ""
-            }
-        }
-    }
-
-    public struct ProofContainer:Codable, Equatable {
-        public let mint:String
-        public let proofs:[Proof]
-        
-        public init(mint: String, proofs: [Proof]) {
-            self.mint = mint
+        init(proofs: [String: [ProofRepresenting]],
+             unit: String,
+             memo: String? = nil) {
             self.proofs = proofs
+            self.unit = unit
+            self.memo = memo
+        }
+        
+        init(token:TokenV3) throws {
+            self.memo = token.memo
+            self.unit = token.unit ?? "sat" // technically not ideal, there might be non-sat V3 tokens
+            self.proofs = Dictionary(uniqueKeysWithValues: token.token.map { ($0.mint, $0.proofs) })
+        }
+        
+        init(token:TokenV4) throws {
+            self.memo = token.memo
+            self.unit = token.unit
+            
+            var proofsPerMint = [String: [ProofRepresenting]]()
+            var ps = [ProofRepresenting]()
+            
+            for entry in token.tokens {
+                ps.append(contentsOf: entry.proofs.map({ p in
+                    Proof(keysetID: String(bytes: entry.keysetID),
+                          amount: p.amount,
+                          secret: p.secret,
+                          C: String(bytes: p.signature))
+                    // TODO: needs to take DLEQ data into account
+                }))
+            }
+            
+            proofsPerMint[token.mint] = ps
+            
+            self.proofs = proofsPerMint
+        }
+        
+        private func makeV3() throws -> TokenV3 {
+            
+            let proofsContainers = proofs.map { (mintURLString, proofList) in
+                ProofContainer(mint: mintURLString,
+                               proofs: proofList.map({ p in
+                    Proof(keysetID: p.keysetID,
+                          amount: p.amount,
+                          secret: p.secret,
+                          C: p.C)
+                }))
+            }
+            
+            return TokenV3(token: proofsContainers,
+                           memo: self.memo,
+                           unit: self.unit)
+            
+        }
+        
+        private func makeV4() throws -> TokenV4 {
+            guard proofs.count < 2 else {
+                throw CashuError.tokenEncoding
+            }
+            
+            guard let (mintURLstring, proofList) = proofs.first else {
+                throw CashuError.tokenEncoding
+            }
+            
+            let byKeysetID = Dictionary(grouping: proofList, by: { $0.keysetID })
+            
+            let tokenEntries = try byKeysetID.map { (id, ps) in
+                TokenV4.TokenEntry(keysetID: Data(try id.bytes),
+                                   proofs: try ps.map({ p in
+                    TokenV4.TokenEntry.Proof(amount: p.amount,
+                                             secret: p.secret,
+                                             signature: Data(try p.C.bytes),
+                                             dleqProof: nil,
+                                             witness: nil)
+                }))
+            }
+            
+            return TokenV4(mint: mintURLstring,
+                           unit: self.unit,
+                           memo: self.memo,
+                           tokens: tokenEntries)
         }
     }
 }
 
 extension String {
+    
     public func deserializeToken() throws -> CashuSwift.Token {
-        var noPrefix = self
-        // needs to be in the right order to avoid only stripping cashu: and leaving //
-        if self.hasPrefix("cashu://") {
-            noPrefix = String(self.dropFirst("cashu://".count))
-        }
-        if self.hasPrefix("cashu:") {
-            noPrefix = String(self.dropFirst("cashu:".count))
-        }
         
-        if noPrefix.hasPrefix("cashuA") {
-            return try CashuSwift.Token.decodeV3(tokenString: noPrefix)
-        } else if noPrefix.hasPrefix("cashuB") {
-            return try CashuSwift.Token.decodeV4(tokenString: noPrefix)
+        if self.hasPrefix("cashuA") {
+            return try CashuSwift.Token(token: CashuSwift.TokenV3(tokenString: self))
+            
+        } else if self.hasPrefix("cashuB") {
+            return try CashuSwift.Token(token: CashuSwift.TokenV4(tokenString: self))
+            
         } else {
-            throw CashuError.invalidToken
+            throw CashuError.tokenDecoding("Token string does not start with 'cashuA' or 'cashuB'")
         }
     }
     
-    func decodeBase64UrlSafe() -> String? {
-        var base64 = self
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-
-        // Check if padding is needed
-        let mod4 = base64.count % 4
-        if mod4 != 0 {
-            base64 += String(repeating: "=", count: 4 - mod4)
-        }
-        guard let data = Data(base64Encoded: base64, options: .ignoreUnknownCharacters) else {
-            return nil
-        }
-        let string = String(data: data, encoding: .ascii)
-        return string
-    }
-
-    func encodeBase64UrlSafe(removePadding: Bool = false) throws -> String {
-        guard let base64Encoded = self.data(using: .ascii)?.base64EncodedString() else {
-            throw CashuError.tokenEncoding
-        }
-        var urlSafeBase64 = base64Encoded
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-
-        if removePadding {
-            urlSafeBase64 = urlSafeBase64.trimmingCharacters(in: CharacterSet(charactersIn: "="))
-        }
-
-        return urlSafeBase64
-    }
-    
-    func makeURLSafe() -> String {
-        return self
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
 }

--- a/Sources/cashu-swift/TokenV3.swift
+++ b/Sources/cashu-swift/TokenV3.swift
@@ -1,0 +1,132 @@
+//
+//  File.swift
+//  
+//
+//  Created by zm on 07.05.24.
+//
+
+import Foundation
+import OSLog
+
+fileprivate var logger = Logger(subsystem: "cashu-swift", category: "Token")
+
+extension CashuSwift {
+    
+    public enum TokenVersion:Codable {
+        case V3
+        case V4
+    }
+
+    public struct TokenV3: Codable, Equatable {
+        public static func == (lhs: TokenV3, rhs: TokenV3) -> Bool {
+            lhs.token == rhs.token && lhs.memo == rhs.memo && lhs.unit == rhs.unit
+        }
+        
+        public let token:[ProofContainer]
+        public let memo:String?
+        public let unit:String?
+        
+        public init(token: [ProofContainer],
+                    memo: String? = nil,
+                    unit:String? = nil) {
+            self.token = token
+            self.memo = memo
+            self.unit = unit
+        }
+        
+        enum CodingKeys:String, CodingKey {
+            case token
+            case memo
+            case unit
+        }
+        
+        init(tokenString: String) throws {
+            let noPrefix = String(tokenString.dropFirst(6))
+            guard let jsonData = noPrefix.decodeBase64UrlSafe() else {
+                throw CashuError.tokenDecoding("Unable to decode base64 url safe string to data.")
+            }
+            self = try JSONDecoder().decode(TokenV3.self, from: jsonData)
+        }
+        
+        public func serialize() throws -> String {
+            return try encodeV3()
+        }
+        
+        private func encodeV3() throws -> String {
+            let jsonData = try JSONEncoder().encode(self)
+            let jsonString = String(data: jsonData, encoding: .utf8)!
+            let safeString = try jsonString.encodeBase64UrlSafe()
+            return "cashuA" + safeString
+        }
+        
+        func prettyJSON() -> String {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            do {
+                let data = try encoder.encode(self)
+                return String(data: data, encoding: .utf8) ?? ""
+            } catch {
+                return ""
+            }
+        }
+    }
+
+    public struct ProofContainer: Codable, Equatable {
+        public let mint:String
+        public let proofs:[Proof]
+        
+        public init(mint: String, proofs: [Proof]) {
+            self.mint = mint
+            self.proofs = proofs
+        }
+    }
+}
+
+extension String {
+    
+    var urlSafe: String {
+        get {
+            self.replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+        }
+    }
+
+    func encodeBase64UrlSafe(removePadding: Bool = false) throws -> String {
+        guard let base64Encoded = self.data(using: .ascii)?.base64EncodedString() else {
+            throw CashuError.tokenEncoding
+        }
+        
+        var urlSafeBase64 = base64Encoded.urlSafe
+
+        if removePadding {
+            urlSafeBase64 = urlSafeBase64.trimmingCharacters(in: CharacterSet(charactersIn: "="))
+        }
+
+        return urlSafeBase64
+    }
+    
+    func decodeBase64UrlSafe() -> Data? {
+        var base64 = self
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        // Check if padding is needed
+        let mod4 = base64.count % 4
+        if mod4 != 0 {
+            base64 += String(repeating: "=", count: 4 - mod4)
+        }
+        
+        return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    }
+}
+
+extension Data {
+    
+    var base64URLsafe:String {
+        let string = self.base64EncodedString()
+        let urlSafeString = string.replacingOccurrences(of: "+", with: "-")
+                                  .replacingOccurrences(of: "/", with: "_")
+        return urlSafeString
+    }
+    
+}

--- a/Sources/cashu-swift/TokenV4.swift
+++ b/Sources/cashu-swift/TokenV4.swift
@@ -1,0 +1,255 @@
+import Foundation
+import SwiftCBOR
+
+extension CashuSwift {
+    struct TokenV4 {
+        let mint: String          // "m" - mint URL
+        let unit: String          // "u" - currency unit
+        let memo: String?         // "d" - optional memo
+        let tokens: [TokenEntry]  // "t" - array of token entries
+
+        struct TokenEntry {
+            let keysetID: Data                    // "i" - keyset ID
+            let proofs: [Proof]                   // "p" - array of proofs
+
+            struct Proof {
+                let amount: Int                   // "a" - amount
+                let secret: String                // "s" - secret
+                let signature: Data               // "c" - signature
+                let dleqProof: DLEQProof?         // "d" - optional DLEQ proof
+                let witness: String?              // "w" - optional witness
+
+                struct DLEQProof {
+                    let e: Data   // "e"
+                    let s: Data   // "s"
+                    let r: Data   // "r"
+                }
+            }
+        }
+    }
+}
+
+// MARK: - CBOR Extensions
+
+extension CBOR {
+    func asMap() -> [CBOR: CBOR]? {
+        if case let .map(map) = self {
+            return map
+        }
+        return nil
+    }
+
+    func asArray() -> [CBOR]? {
+        if case let .array(array) = self {
+            return array
+        }
+        return nil
+    }
+
+    func asString() -> String? {
+        if case let .utf8String(string) = self {
+            return string
+        }
+        return nil
+    }
+
+    func asByteString() -> Data? {
+        if case let .byteString(bytes) = self {
+            return Data(bytes)
+        }
+        return nil
+    }
+
+    func asUnsignedInt() -> UInt64? {
+        if case let .unsignedInt(value) = self {
+            return value
+        }
+        return nil
+    }
+}
+
+// MARK: - TokenV4 Extensions
+
+extension CashuSwift.TokenV4 {
+    init(fromCBOR cbor: CBOR) throws {
+        guard let cborMap = cbor.asMap() else {
+            throw DecodingError.typeMismatch(
+                CBOR.self,
+                DecodingError.Context(codingPath: [], debugDescription: "Expected CBOR map")
+            )
+        }
+
+        guard let mint = cborMap[.utf8String("m")]?.asString(),
+              let unit = cborMap[.utf8String("u")]?.asString(),
+              let tokensArray = cborMap[.utf8String("t")]?.asArray() else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Missing required fields in TokenV4")
+            )
+        }
+
+        self.mint = mint
+        self.unit = unit
+        self.memo = cborMap[.utf8String("d")]?.asString()
+        self.tokens = try tokensArray.map { try TokenEntry(fromCBOR: $0) }
+    }
+
+    func toCBOR() -> CBOR {
+        var cborMap: [CBOR: CBOR] = [
+            .utf8String("m"): .utf8String(mint),
+            .utf8String("u"): .utf8String(unit),
+            .utf8String("t"): .array(tokens.map { $0.toCBOR() })
+        ]
+        if let memo = memo {
+            cborMap[.utf8String("d")] = .utf8String(memo)
+        }
+        return .map(cborMap)
+    }
+}
+
+extension CashuSwift.TokenV4.TokenEntry {
+    init(fromCBOR cbor: CBOR) throws {
+        guard let cborMap = cbor.asMap() else {
+            throw DecodingError.typeMismatch(
+                CBOR.self,
+                DecodingError.Context(codingPath: [], debugDescription: "Expected CBOR map")
+            )
+        }
+
+        guard let keysetIDData = cborMap[.utf8String("i")]?.asByteString(),
+              let proofsArray = cborMap[.utf8String("p")]?.asArray() else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Missing required fields in TokenEntry")
+            )
+        }
+
+        self.keysetID = keysetIDData
+        self.proofs = try proofsArray.map { try Proof(fromCBOR: $0) }
+    }
+
+    func toCBOR() -> CBOR {
+        let cborMap: [CBOR: CBOR] = [
+            .utf8String("i"): .byteString([UInt8](keysetID)),
+            .utf8String("p"): .array(proofs.map { $0.toCBOR() })
+        ]
+        return .map(cborMap)
+    }
+}
+
+extension CashuSwift.TokenV4.TokenEntry.Proof {
+    init(fromCBOR cbor: CBOR) throws {
+        guard let cborMap = cbor.asMap() else {
+            throw DecodingError.typeMismatch(
+                CBOR.self,
+                DecodingError.Context(codingPath: [], debugDescription: "Expected CBOR map")
+            )
+        }
+
+        guard let amountValue = cborMap[.utf8String("a")]?.asUnsignedInt(),
+              let secret = cborMap[.utf8String("s")]?.asString(),
+              let signatureData = cborMap[.utf8String("c")]?.asByteString() else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Missing required fields in Proof")
+            )
+        }
+
+        self.amount = Int(amountValue)
+        self.secret = secret
+        self.signature = signatureData
+        self.witness = cborMap[.utf8String("w")]?.asString()
+
+        if let dleqCBOR = cborMap[.utf8String("d")] {
+            self.dleqProof = try DLEQProof(fromCBOR: dleqCBOR)
+        } else {
+            self.dleqProof = nil
+        }
+    }
+
+    func toCBOR() -> CBOR {
+        var cborMap: [CBOR: CBOR] = [
+            .utf8String("a"): .unsignedInt(UInt64(amount)),
+            .utf8String("s"): .utf8String(secret),
+            .utf8String("c"): .byteString([UInt8](signature))
+        ]
+        if let dleq = dleqProof {
+            cborMap[.utf8String("d")] = dleq.toCBOR()
+        }
+        if let witness = witness {
+            cborMap[.utf8String("w")] = .utf8String(witness)
+        }
+        return .map(cborMap)
+    }
+}
+
+extension CashuSwift.TokenV4.TokenEntry.Proof.DLEQProof {
+    init(fromCBOR cbor: CBOR) throws {
+        guard let cborMap = cbor.asMap() else {
+            throw DecodingError.typeMismatch(
+                CBOR.self,
+                DecodingError.Context(codingPath: [], debugDescription: "Expected CBOR map")
+            )
+        }
+
+        guard let eData = cborMap[.utf8String("e")]?.asByteString(),
+              let sData = cborMap[.utf8String("s")]?.asByteString(),
+              let rData = cborMap[.utf8String("r")]?.asByteString() else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Missing required fields in DLEQProof")
+            )
+        }
+
+        self.e = eData
+        self.s = sData
+        self.r = rData
+    }
+
+    func toCBOR() -> CBOR {
+        let cborMap: [CBOR: CBOR] = [
+            .utf8String("e"): .byteString([UInt8](e)),
+            .utf8String("s"): .byteString([UInt8](s)),
+            .utf8String("r"): .byteString([UInt8](r))
+        ]
+        return .map(cborMap)
+    }
+}
+
+// MARK: - Serialization
+
+extension CashuSwift.TokenV4 {
+    public func serialize() throws -> String {
+        let cborValue = self.toCBOR()
+        let cborData = cborValue.encode()
+        
+        let base64URLSafe = Data(cborData).base64EncodedString()
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+
+        return "cashuB\(base64URLSafe)"
+    }
+    
+    init(tokenString: String) throws {
+        guard tokenString.hasPrefix("cashuB") else {
+            throw CashuError.tokenDecoding("Tried to decode V4 token that does not start with 'cashuB'")
+        }
+        
+        let base64URLSafeString = String(tokenString.dropFirst(6))
+        
+        guard let cborData = base64URLSafeString.decodeBase64UrlSafe() else {
+            throw CashuError.tokenDecoding("Could not turn base64 string into data.")
+        }
+        
+        // Decode CBOR data into a CBOR value
+        guard let cborValue = try? CBOR.decode([UInt8](cborData)) else {
+            throw CashuError.tokenDecoding("Could not turn data into CBOR")
+        }
+        
+        self = try CashuSwift.TokenV4(fromCBOR: cborValue)
+    }
+}
+
+// MARK: - Data Extension
+
+extension Data {
+    func hexEncodedString() -> String {
+        return map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -7,29 +7,6 @@ import SwiftCBOR
 
 final class cashu_swiftTests: XCTestCase {
     
-//    func testEncoding() throws {
-//        
-//        let proof1 = CashuSwift.Proof(keysetID: "009a1f293253e41e",
-//                           amount: 2,
-//                           secret: "407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837",
-//                           C: "02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea")
-//        let proof2 = CashuSwift.Proof(keysetID: proof1.keysetID,
-//                           amount: 8,
-//                           secret: "fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be",
-//                           C: "029e8e5050b890a7d6c0968db16bc1d5d5fa040ea1de284f6ec69d61299f671059")
-//        
-//        let proofContainer = CashuSwift.ProofContainer(mint: "https://8333.space:8333",
-//                                            proofs: [proof1, proof2])
-//        
-//        let token = CashuSwift.TokenV3(token: [proofContainer], memo: "Thank you.", unit: "sat")
-//        
-//        print(token.prettyJSON())
-//        
-//        let testToken = try token.serialize(.V3)
-//        
-////        XCTAssertEqual(token, try testToken.deserializeToken())
-//    }
-    
     func testSecretSerialization() throws {
         
         // test that deserialization from string works properly
@@ -227,7 +204,7 @@ final class cashu_swiftTests: XCTestCase {
         }
     }
     
-//    func testMintingWithDetSec() async throws {
+    func testMintingWithDetSec() async throws {
 //        let mintURL = URL(string: "http://localhost:3339")!
 //        
 //        let mint = try await CashuSwift.loadMint(url: mintURL)
@@ -246,7 +223,7 @@ final class cashu_swiftTests: XCTestCase {
 //        for _ in 0...3 {
 //            (proofs, _) = try await CashuSwift.swap(mint: mint, proofs: proofs, seed: seed)
 //        }
-//    }
+    }
     
     func testSendReceive() async throws {
         let url = URL(string: "http://localhost:3339")!
@@ -258,7 +235,7 @@ final class cashu_swiftTests: XCTestCase {
         let (token, change) = try await CashuSwift.send(mint: mint, proofs: proofs, amount: 15)
 //        let tokenString = try token.serialize(.V3)
         
-        print(token.token.first!.proofs.sum)
+        print(CashuSwift.sum(token.proofsByMint.first!.value))
         print(CashuSwift.sum(change))
         
         let received = try await CashuSwift.receive(mint: mint, token: token)
@@ -286,7 +263,7 @@ final class cashu_swiftTests: XCTestCase {
         XCTAssert(result.paid)
     }
     
-//    func testMeltExt() async throws {
+    func testMeltExt() async throws {
 //        let url = URL(string: "https://mint.macadamia.cash")!
 //        let mint = try await CashuSwift.loadMint(url: url, type: CashuSwift.Mint.self)
 //        let qr = CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 128)
@@ -308,9 +285,9 @@ final class cashu_swiftTests: XCTestCase {
 //        print(CashuSwift.sum(result.change))
 //        
 //        XCTAssert(result.paid)
-//    }
+    }
     
-//    func testMeltReal() async throws {
+    func testMeltReal() async throws {
 //        let mint1 = try await Mint(with: URL(string: "https://mint.macadamia.cash")!)
 //        let mint2 = try await Mint(with: URL(string: "https://8333.space:3338")!)
 //        
@@ -331,7 +308,7 @@ final class cashu_swiftTests: XCTestCase {
 //        let meltResult = try await mint1.melt(quote: meltQuote, proofs: proofs)
 //        print(meltResult)
 //        print(meltResult.change.sum)
-//    }
+    }
     
     func testBlankOutputCalculation() {
         let overpayed = 1000
@@ -366,7 +343,7 @@ final class cashu_swiftTests: XCTestCase {
         
         let (token, _) = try await CashuSwift.send(mint: mint, proofs: proofs)
         
-        _ = try await CashuSwift.swap(mint: mint, proofs: token.token.first!.proofs)
+        _ = try await CashuSwift.swap(mint: mint, proofs: token.proofsByMint.first!.value)
         
         let states = try await CashuSwift.check(proofs, mint: mint)
         print(states.debugPretty())
@@ -468,15 +445,14 @@ final class cashu_swiftTests: XCTestCase {
         print(selection4 ?? "nil")
     }
     
-//    func testInfoLoad() async throws {
+    func testInfoLoad() async throws {
 //        let url = URL(string: "http://localhost:3339")!
 //        let mint = try await CashuSwift.loadMint(url: url)
 //        
 //        let info = try await CashuSwift.loadInfoFromMint(mint) as! CashuSwift.MintInfo0_16
 //        
 //        print(info)
-//        
-//    }
+    }
     
     func testErrorHandling() async throws {
         
@@ -542,8 +518,6 @@ final class cashu_swiftTests: XCTestCase {
         
     }
     
-    
-    
     func testTokenV4Serde() async throws {
        
         let url = URL(string: "https://testnut.cashu.space")!
@@ -585,5 +559,20 @@ final class cashu_swiftTests: XCTestCase {
     func testCreateRandomPubkey() {
         let priv = try! secp256k1.Signing.PrivateKey()
         print(String(bytes: priv.publicKey.dataRepresentation))
+    }
+    
+    func testMultiReceive() async throws {
+//        let mint1 = try await CashuSwift.loadMint(url: URL(string: "https://testmint.macadamia.cash")!)
+//        let mint2 = try await CashuSwift.loadMint(url: URL(string: "https://testnut.cashu.space")!)
+//        
+//        let mints = [mint1, mint2]
+//        
+//        let mmt = "cashuAeyJtZW1vIjoiV2FsbGV0IERyYWluIiwidG9rZW4iOlt7Im1pbnQiOiJodHRwczpcL1wvdGVzdG51dC5jYXNodS5zcGFjZSIsInByb29mcyI6W3sic2VjcmV0IjoiMDAyYmU3NGIwNzQ5NDBlN2Y5N2VkMWZmMzRlMTVlMTkyM2I1ODMzZmY0NjhjMDU0YzFiMjA3ODZmYzZmOTEwYSIsImFtb3VudCI6MSwiaWQiOiIwMDlhMWYyOTMyNTNlNDFlIiwiQyI6IjAyOTg5NWQ0N2MyMWZjM2M3ZDQwOGQ4MGQ5ZmVlYjMzNDJjYWQ1MjY5ZjQ5MTRkZjBiMTE1N2Q1ZjMxNTgwZDIwNCJ9LHsiYW1vdW50Ijo0LCJpZCI6IjAwOWExZjI5MzI1M2U0MWUiLCJzZWNyZXQiOiIyMmZmMTM2MzJlMjM1ODRiY2Y4MWE4ZTAxNGQ5ZmQ4MmY2OGNhZTFhZGQzZmRkOGM4ZDk4NGY1ZWI4NjQ2ZTNjIiwiQyI6IjAzNWRkYjBlODhjNWFlZmNjYTAyNDZkODQzNmY2YTAxYWU0OTE2Yjk3ZTNkZTNmOGY3YzQ0MDIyODcyYzhhZjg0MCJ9LHsiaWQiOiIwMDlhMWYyOTMyNTNlNDFlIiwiYW1vdW50IjoxNiwiQyI6IjAzYjBiZmIzNWU0OGI1YmUxNmM4MGM3NGY3NTgyZDgzMjNlNmJkM2E3N2M1ZWY1ZmE4NjY3MDIwNThiNWViOGViYyIsInNlY3JldCI6Ijg3NzEzYjRhN2I0ZDcxMmY3Njc0M2IyODQ5NTQ3NjkxNDQ0M2U1YmExOGExZDIxMWM0NzU3Y2I3NmE1M2YwNWIifV19LHsibWludCI6Imh0dHBzOlwvXC90ZXN0bWludC5tYWNhZGFtaWEuY2FzaCIsInByb29mcyI6W3siQyI6IjAzMzVmYWFhZmE0ODgxNjI4M2IyM2U2YjNjNDRmODU2NDcwZmE1ZjgwMzdkNDg2OGNmNDkwNDY2MmRhYWE5NDRjMCIsImFtb3VudCI6Miwic2VjcmV0IjoiYWNlYWU0MzNiNTJhNGFjZWNiNWYyMTFiMzkwNTc4OTljZTlkMTBkY2I0MDM3YzUyZjIxNzNjMTljNTdiZGZiYiIsImlkIjoiMDBlYTBkNDE2NjQ0MTI4YyJ9LHsiYW1vdW50Ijo4LCJzZWNyZXQiOiI4N2Y4MWRiNGVkMmFiNWIzYjMwMjQxNTJmZjg2MzIzZThiMWMyYTM5MzI5MzI4MTBlMTVjODI5YWJkMmUwYTZjIiwiaWQiOiIwMGVhMGQ0MTY2NDQxMjhjIiwiQyI6IjAzZmU0YjRhZDIzNGY5MzI1YjA4MDIxMjcwMjBlY2IzNDg1MGJhZWIzNmZlZmEzZmE0MjFlZjc4M2M0MzA4YWE3NiJ9LHsic2VjcmV0IjoiYjEwYmFiZmZhZDhkZmNkYWQzZTkwYmE4MmI4ZWRiMGMxZTNjNGE5MDlmMjNmOWY2MGRmOTczMjRiMzg4YzJlMiIsImFtb3VudCI6MzIsImlkIjoiMDBlYTBkNDE2NjQ0MTI4YyIsIkMiOiIwMjJjNGI5MGIxNTc5M2RmNDJjMTIxMTUyNjM4NTBiNmE2MzRmNzBkMzZmNzljODc4MDlmYzgwNjRmNTM4OTlmNWMifV19XX0="
+//        
+//        let token = try mmt.deserializeToken()
+//        
+//        let receivedProofs = try await mints.receive(token: token)
+//        
+//        print(receivedProofs)
     }
 }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -528,6 +528,11 @@ final class cashu_swiftTests: XCTestCase {
                                      unit: qr.unit,
                                      memo: "bingo bango")
         
+        let codable = try JSONEncoder().encode(token1)
+        let decodable = try JSONDecoder().decode(CashuSwift.Token.self, from: codable)
+        
+        XCTAssertEqual(token1, decodable)
+        
         print(try token1.serialize(to: .V3))
         
         let q2 = try await CashuSwift.getQuote(mint: mint,


### PR DESCRIPTION
This PR contains a refactor of the `CashuSwift.Token` object to make it more generalized and allow for easy serialization to V3 and V4 (CBOR-encoded) token strings as well as deserialization back to the `Token` object.