### PR TITLE
Add melt quote state check, build blank outputs separately

### DIFF
--- a/Sources/cashu-swift/Crypto.swift
+++ b/Sources/cashu-swift/Crypto.swift
@@ -29,11 +29,11 @@ extension CashuSwift {
         /// Generate a list of blinded `Output`s and corresponding blindingFactors and secrets for later unblinding Promises from the Mint.
         /// Not specifying `deterministicFactors` will give you random outputs that can not be recreated via seed phrase backup
         static func generateOutputs(amounts:[Int],
-                             keysetID:String,
-                             deterministicFactors:(seed:String,
-                                                   counter:Int)? = nil)  throws -> (outputs: [Output],
-                                                                                    blindingFactors: [String],
-                                                                                    secrets:[String]) {
+                                           keysetID:String,
+                                           deterministicFactors:(seed:String,
+                                                                 counter:Int)? = nil)  throws -> (outputs: [Output],
+                                                                                                  blindingFactors: [String],
+                                                                                                  secrets:[String]) {
 
             var outputs = [Output]()
             var blindingFactors = [String]()
@@ -119,9 +119,14 @@ extension CashuSwift {
         //MARK: - UNBLINDING
         
         static func unblindPromises(_ promises:[Promise],
-                             blindingFactors:[String],
-                             secrets:[String],
-                             keyset:Keyset) throws -> [Proof] {
+                                           blindingFactors:[String],
+                                           secrets:[String],
+                                           keyset:Keyset) throws -> [Proof] {
+            
+            guard promises.count == blindingFactors.count &&
+                  blindingFactors.count == secrets.count else {
+                throw Crypto.Error.unblinding("promises, blindingFactors and secrets do not have matching counts!")
+            }
             
             var proofs = [Proof]()
             for i in 0..<promises.count {

--- a/Sources/cashu-swift/Crypto.swift
+++ b/Sources/cashu-swift/Crypto.swift
@@ -123,9 +123,10 @@ extension CashuSwift {
                                            secrets:[String],
                                            keyset:Keyset) throws -> [Proof] {
             
-            guard promises.count == blindingFactors.count &&
-                  blindingFactors.count == secrets.count else {
-                throw Crypto.Error.unblinding("promises, blindingFactors and secrets do not have matching counts! promises: \(promises.count), bfs: \(blindingFactors.count), secrets: \(secrets.count)")
+            // making sure promises is not larger than the other two lists to prevent out of bounds crash
+            guard promises.count <= blindingFactors.count &&
+                    promises.count <= secrets.count else {
+                throw Crypto.Error.unblinding("Number of promises to unblind is larger than blindingFactors or secrets. This can lead to a out-of-bounds crash!")
             }
             
             var proofs = [Proof]()

--- a/Sources/cashu-swift/Crypto.swift
+++ b/Sources/cashu-swift/Crypto.swift
@@ -125,7 +125,7 @@ extension CashuSwift {
             
             guard promises.count == blindingFactors.count &&
                   blindingFactors.count == secrets.count else {
-                throw Crypto.Error.unblinding("promises, blindingFactors and secrets do not have matching counts!")
+                throw Crypto.Error.unblinding("promises, blindingFactors and secrets do not have matching counts! promises: \(promises.count), bfs: \(blindingFactors.count), secrets: \(secrets)")
             }
             
             var proofs = [Proof]()

--- a/Sources/cashu-swift/Crypto.swift
+++ b/Sources/cashu-swift/Crypto.swift
@@ -125,7 +125,7 @@ extension CashuSwift {
             
             guard promises.count == blindingFactors.count &&
                   blindingFactors.count == secrets.count else {
-                throw Crypto.Error.unblinding("promises, blindingFactors and secrets do not have matching counts! promises: \(promises.count), bfs: \(blindingFactors.count), secrets: \(secrets)")
+                throw Crypto.Error.unblinding("promises, blindingFactors and secrets do not have matching counts! promises: \(promises.count), bfs: \(blindingFactors.count), secrets: \(secrets.count)")
             }
             
             var proofs = [Proof]()

--- a/Sources/cashu-swift/Error.swift
+++ b/Sources/cashu-swift/Error.swift
@@ -41,7 +41,6 @@ public enum CashuError: Swift.Error {
     case invoiceAlreadyPaid // 20006
     case quoteIsExpired // 20007
     case unknownError(String)
-    
 }
 
 extension CashuError: Equatable {

--- a/Sources/cashu-swift/Keyset.swift
+++ b/Sources/cashu-swift/Keyset.swift
@@ -13,7 +13,7 @@ extension CashuSwift {
         let keysets:[Keyset]
     }
 
-    public struct Keyset: Codable {
+    public struct Keyset: Codable, Sendable {
         public let keysetID: String
         public var keys: Dictionary<String, String>
         public var derivationCounter:Int

--- a/Sources/cashu-swift/Output.swift
+++ b/Sources/cashu-swift/Output.swift
@@ -10,6 +10,12 @@ import Foundation
 extension CashuSwift {
     // AKA BlindedMessage
     public struct Output: Codable {
+        enum CodingKeys: String, CodingKey {
+            case amount
+            case B_ = "B_"
+            case id
+        }
+        
         public let amount: Int
         public let B_: String
         public let id: String

--- a/Sources/cashu-swift/Quote.swift
+++ b/Sources/cashu-swift/Quote.swift
@@ -98,6 +98,7 @@ extension CashuSwift {
                 case paymentPreimage = "payment_preimage"
                 case change
                 case quoteRequest
+                case state
             }
         }
         

--- a/Sources/cashu-swift/Restore.swift
+++ b/Sources/cashu-swift/Restore.swift
@@ -22,5 +22,6 @@ extension CashuSwift {
         public let derivationCounter: Int
         public let unitString: String
         public let proofs: [ProofRepresenting]
+        public let inputFeePPK: Int
     }
 }

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -264,7 +264,8 @@ public enum CashuSwift {
     
     // MARK: - MELT
     ///Allows a wallet to create and persist NUT-08 blank outputs for an overpaid amount `sum(proofs) - quote.amount - inputFee`
-    public static func generateBlankOutputs(for amountOverpaid: Int,
+    public static func generateBlankOutputs(quote: CashuSwift.Bolt11.MeltQuote,
+                                            proofs: [some ProofRepresenting],
                                             mint: MintRepresenting,
                                             unit: String,
                                             seed: String? = nil) throws -> ((outputs: [Output],
@@ -282,6 +283,9 @@ public enum CashuSwift {
         } else {
             deterministicFactors = nil
         }
+        
+        let inputFee = try calculateFee(for: proofs, of: mint)
+        let amountOverpaid = proofs.sum - quote.amount - quote.feeReserve - inputFee
         
         let blankDistribution = Array(repeating: 0, count: calculateNumberOfBlankOutputs(amountOverpaid))
         

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -578,7 +578,8 @@ public enum CashuSwift {
             let result = KeysetRestoreResult(keysetID: keyset.keysetID,
                                              derivationCounter: lastMatchCounter + 1,
                                              unitString: keyset.unit,
-                                             proofs: spendableProofs)
+                                             proofs: spendableProofs,
+                                             inputFeePPK: keyset.inputFeePPK)
             results.append(result)
             logger.info("Found \(spendableProofs.count) spendable proofs for keyset \(keyset.keysetID)")
         }

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -263,8 +263,9 @@ public enum CashuSwift {
     }
     
     // MARK: - MELT
-    public static func generateBlankOutputs(mint: MintRepresenting,
-                                            count: Int,
+    ///Allows a wallet to create and persist NUT-08 blank outputs for an overpaid amount `sum(proofs) - quote.amount - inputFee`
+    public static func generateBlankOutputs(for amountOverpaid: Int,
+                                            mint: MintRepresenting,
                                             unit: String,
                                             seed: String? = nil) throws -> ((outputs: [Output],
                                                                              blindingFactors: [String],
@@ -282,7 +283,9 @@ public enum CashuSwift {
             deterministicFactors = nil
         }
         
-        return try Crypto.generateOutputs(amounts: Array(repeating: 0, count: count),
+        let blankDistribution = Array(repeating: 0, count: calculateNumberOfBlankOutputs(amountOverpaid))
+        
+        return try Crypto.generateOutputs(amounts: blankDistribution,
                                           keysetID: activeKeyset.keysetID,
                                           deterministicFactors: deterministicFactors)
     }

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -397,7 +397,7 @@ public enum CashuSwift {
                 return (true, [])
             }
             
-            guard let id = ids.first, ids.count == 0 else {
+            guard let id = ids.first, ids.count == 1 else {
                 throw CashuError.unknownError("could not determine singular keyset id from blankOutput list. result: \(ids)")
             }
             

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -560,9 +560,7 @@ public enum CashuSwift {
                 logger.debug("No ecash to restore for keyset \(keyset.keysetID).")
                 continue
             }
-            
-//            derivationCounters[keyset.keysetID] = lastMatchCounter + 1
-            
+                        
             let states = try await check(proofs, mint: mint) // ignores pending but should not
 
             guard states.count == proofs.count else {
@@ -574,7 +572,6 @@ public enum CashuSwift {
                 if states[i] == .unspent { spendableProofs.append(proofs[i]) }
             }
             
-//            spendableProofs.forEach({ restoredProofs.append(($0, keyset.unit)) })
             let result = KeysetRestoreResult(keysetID: keyset.keysetID,
                                              derivationCounter: lastMatchCounter + 1,
                                              unitString: keyset.unit,

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -397,16 +397,6 @@ public enum CashuSwift {
                 return (true, [])
             }
             
-            guard Set([blankOutputs.blindingFactors.count,
-                       blankOutputs.secrets.count,
-                       blankOutputs.outputs.count,
-                       promises.count]).count == 1 else {
-                throw CashuError.unknownError("""
-                while unblinding change from overpaid LN fees:
-                blindingFactors, secrets, outputs and change promises
-                """)
-            }
-            
             guard let id = ids.first, ids.count == 0 else {
                 throw CashuError.unknownError("could not determine singular keyset id from blankOutput list. result: \(ids)")
             }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -574,4 +574,19 @@ final class cashu_swiftTests: XCTestCase {
 //        
 //        print(receivedProofs)
     }
+    
+    func testMeltQuoteState() async throws {
+        let url = URL(string: "https://testmint.macadamia.cash")!
+        let mint = try await CashuSwift.loadMint(url: url)
+        
+        let quoteRequest = CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 32)
+        let quote = try await CashuSwift.getQuote(mint: mint, quoteRequest: quoteRequest)
+        let proofs = try await CashuSwift.issue(for: quote, on:mint)
+        
+        let meltQuoteRequest = CashuSwift.Bolt11.RequestMeltQuote(unit: "sat", request: "lnbc10n1pncqzp0pp5kht9qmh87p59qfg3uuwk5g39f7s5ts8993xn97fdtlc9cff6qarqdqqcqzzsxqyz5vqsp5flgz3g0szvty3x9tk042ehvregv2pgr5593edp4c4ljaypv0zjcq9p4gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqysgqz7va7hqrcz0vtnh0rvjze4k58eyjsdut8wgffn49mm0xjlgzrkz3l9jlhjguppt79h3ytjx7qjxcvyq6c3a7vg9vf687vll2yvvzrqcq568eu4", options: nil)
+        let meltQuote = try await CashuSwift.getQuote(mint: mint, quoteRequest: meltQuoteRequest)
+        let result = try await CashuSwift.melt(mint: mint, quote: meltQuote, proofs: proofs)
+        
+        print(meltQuote.quote)
+    }
 }


### PR DESCRIPTION
To enable a wallet to persist all relevant data of a melt request including blank outputs for overpaid amounts, the PR adds the ability to create the outputs beforehand as well as passing them to `.melt` and `meltState` functions.
This allows the wallet to repeat the melt request and unblind the change once the payment is successful.