### PR TITLE
Fix: Seed Phrase Restore Bug

### DIFF
--- a/Sources/cashu-swift/Crypto.swift
+++ b/Sources/cashu-swift/Crypto.swift
@@ -119,16 +119,20 @@ extension CashuSwift {
         //MARK: - UNBLINDING
         
         static func unblindPromises(_ promises:[Promise],
-                                           blindingFactors:[String],
-                                           secrets:[String],
-                                           keyset:Keyset) throws -> [Proof] {
+                                    blindingFactors:[String],
+                                    secrets:[String],
+                                    keyset:Keyset) throws -> [Proof] {
             
-            // making sure promises is not larger than the other two lists to prevent out of bounds crash
-            guard promises.count <= blindingFactors.count &&
-                    promises.count <= secrets.count else {
-                throw Crypto.Error.unblinding("Number of promises to unblind is larger than blindingFactors or secrets. This can lead to a out-of-bounds crash!")
+            guard promises.count == blindingFactors.count,
+                  promises.count == secrets.count else {
+                throw Crypto.Error.unblinding("""
+                    Array length mismatch: 
+                    promises: \(promises.count), 
+                    blindingFactors: \(blindingFactors.count), 
+                    secrets: \(secrets.count)
+                    """)
             }
-            
+                        
             var proofs = [Proof]()
             for i in 0..<promises.count {
                 let promise = promises[i]

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -137,7 +137,7 @@ public enum CashuSwift {
     public static func issue(for quote:Quote,
                              on mint: MintRepresenting,
                              seed:String? = nil,
-                             preferredDistribution:[Int]? = nil) async throws -> [ProofRepresenting] {
+                             preferredDistribution:[Int]? = nil) async throws -> [some ProofRepresenting] {
         
         guard let quote = quote as? Bolt11.MintQuote else {
             throw CashuError.typeMismatch("Quote to issue proofs for was not a Bolt11.MintQuote")

--- a/Sources/cashu-swift/cashu_swift.swift
+++ b/Sources/cashu-swift/cashu_swift.swift
@@ -590,6 +590,8 @@ public enum CashuSwift {
                     response.outputs.contains(where: {newOut in oldOutput.B_ == newOut.B_})
                 }) ?? 0
             }
+            
+            // filter blindingfactor and secret arrays to include only the ones for outputs that exist
             var rs = [String]()
             var xs = [String]()
             for i in 0..<outputs.count {
@@ -600,9 +602,9 @@ public enum CashuSwift {
             }
             
             let batchProofs = try Crypto.unblindPromises(response.signatures,
-                                                        blindingFactors: blindingFactors,
-                                                        secrets: secrets,
-                                                        keyset: keyset)
+                                                         blindingFactors: rs,
+                                                         secrets: xs,
+                                                         keyset: keyset)
             proofs.append(contentsOf: batchProofs)
         }
         currentCounter -= (emptyRuns + 1) * batchSize


### PR DESCRIPTION
Fixes a critical bug where unspendable proofs would be created during restore because an incorrectly unblinded c_ from the mint will still be marked as "UNSPENT" during state check.