### PR TITLE
Add NUT-12 DLEQ verification

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
             targets: ["CashuSwift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", 
-                 from: "0.17.0"),
+        .package(url: "https://github.com/zeugmaster/swift-secp256k1.git",
+                 branch: "main"),
         .package(url: "https://github.com/zeugmaster/BIP32.git",
                  branch: "main"),
         .package(url: "https://github.com/mkrd/Swift-BigInt.git",
@@ -35,7 +35,7 @@ let package = Package(
         .target(
             name: "CashuSwift",
             dependencies: [
-                .product(name: "secp256k1", package: "secp256k1.swift"),
+                .product(name: "secp256k1", package: "swift-secp256k1"),
                 .product(name: "BIP32", package: "BIP32"),
                 .product(name: "BigNumber", package: "Swift-BigInt"),
                 .product(name: "BIP39", package: "BIP39"),

--- a/Sources/cashu-swift/Crypto/Crypto.swift
+++ b/Sources/cashu-swift/Crypto/Crypto.swift
@@ -156,10 +156,18 @@ extension CashuSwift {
                 let C_ = try PublicKey(dataRepresentation: promise.C_.bytes, format: .compressed)
                 let C = try unblind(C_: C_, r: r, A: mintPubKey)
                 
-                proofs.append(Proof(keysetID: promises[i].id,
-                                    amount: promises[i].amount,
-                                    secret: secrets[i],
-                                    C: String(bytes: C.dataRepresentation)))
+                var dleq: DLEQ? = nil
+                if let promiseDLEQ = promise.dleq {
+                    dleq = DLEQ(e: promiseDLEQ.e, s: promiseDLEQ.s, r: blindingFactors[i])
+                }
+                
+                let proof = Proof(keysetID: promises[i].id,
+                                  amount: promises[i].amount,
+                                  secret: secrets[i],
+                                  C: String(bytes: C.dataRepresentation),
+                                  dleq: dleq)
+                
+                proofs.append(proof)
             }
             return proofs
         }

--- a/Sources/cashu-swift/Crypto/Crypto.swift
+++ b/Sources/cashu-swift/Crypto/Crypto.swift
@@ -210,7 +210,7 @@ extension CashuSwift {
             
             let R2 = try sTimesBprime.subtract(eTimesCprime, format: .uncompressed)
 
-            let hash = hashConcat([R1, R2, A, C_])
+            let hash = try hashConcat([R1, R2, A.toFormat(.uncompressed), C_.toFormat(.uncompressed)])
             
             if hash == e {
                 return true
@@ -222,10 +222,8 @@ extension CashuSwift {
         public static func hashConcat(_ publicKeys: [PublicKey]) -> Data {
             
             var concat = ""
-            for k in publicKeys {
-                guard k.dataRepresentation.count == 65 else {
-                    fatalError("input public keys need to be UNCOMPRESSED for this function to work properly")
-                }
+            for var k in publicKeys {
+                k = try! k.toFormat(.uncompressed)
                 concat.append(String(bytes: k.dataRepresentation))
             }
             

--- a/Sources/cashu-swift/Crypto/Crypto.swift
+++ b/Sources/cashu-swift/Crypto/Crypto.swift
@@ -202,8 +202,14 @@ extension CashuSwift {
             throw Error.hashToCurve("No point on the secp256k1 curve could be found.")
         }
         
+//        public static func validDLEQ(for proofs: [Proof], with mint: Mint) -> Bool {
+//            proofs.allSatisfy { proof in
+//                
+//            }
+//        }
+        
         /// Public key
-        public static func verifyDLEQ(A: PublicKey, B_: PublicKey, C_: PublicKey, e: Data, s: Data) throws -> Bool {
+        static func verifyDLEQ(A: PublicKey, B_: PublicKey, C_: PublicKey, e: Data, s: Data) throws -> Bool {
             // R1 = s*G - e*A
             // R2 = s*B' - e*C'
             // e == hash(R1,R2,A,C') # must be True
@@ -225,6 +231,21 @@ extension CashuSwift {
             } else {
                 return false
             }
+        }
+        
+        static func verifyDLEQ(A: PublicKey, C: PublicKey, x: String, e: Data, s: Data, r: Data) throws -> Bool {
+            // Y = hash_to_curve(x)
+            // C' = C + r*A
+            // B' = Y + r*G
+            //
+            // R1 = ... (same as Alice)
+            let Y = try secureHashToCurve(message: x)
+            let rA =  try A.multiply([UInt8](r))
+            let C_ = try C.combine([rA])
+            let rG = try PrivateKey(dataRepresentation: r).publicKey
+            let B_ = try Y.combine([rG])
+            
+            return try verifyDLEQ(A: A, B_: B_, C_: C_, e: e, s: s)
         }
         
         public static func hashConcat(_ publicKeys: [PublicKey]) -> Data {

--- a/Sources/cashu-swift/Crypto/Crypto.swift
+++ b/Sources/cashu-swift/Crypto/Crypto.swift
@@ -210,7 +210,7 @@ extension CashuSwift {
             
             let R2 = try sTimesBprime.subtract(eTimesCprime, format: .uncompressed)
 
-            let hash = try hashConcat([R1, R2, A.toFormat(.uncompressed), C_.toFormat(.uncompressed)])
+            let hash = hashConcat([R1, R2, A, C_])
             
             if hash == e {
                 return true
@@ -222,9 +222,9 @@ extension CashuSwift {
         public static func hashConcat(_ publicKeys: [PublicKey]) -> Data {
             
             var concat = ""
-            for var k in publicKeys {
-                k = try! k.toFormat(.uncompressed)
-                concat.append(String(bytes: k.dataRepresentation))
+            for k in publicKeys {
+                let kData = k.uncompressedRepresentation
+                concat.append(String(bytes: kData))
             }
             
             return Data(SHA256.hash(data: concat.data(using: .utf8)!))

--- a/Sources/cashu-swift/Crypto/Crypto.swift
+++ b/Sources/cashu-swift/Crypto/Crypto.swift
@@ -205,7 +205,7 @@ extension CashuSwift {
             throw Error.hashToCurve("No point on the secp256k1 curve could be found.")
         }
         
-        public static func validDLEQ(for proofs: [Proof], with mint: Mint) throws -> Bool {
+        public static func validDLEQ(for proofs: [Proof], with mint: MintRepresenting) throws -> Bool {
             var checks = [Bool]()
             
             for p in proofs {

--- a/Sources/cashu-swift/Models/Keyset.swift
+++ b/Sources/cashu-swift/Models/Keyset.swift
@@ -26,8 +26,6 @@ extension CashuSwift {
             case inputFeePPK = "input_fee_ppk"
         }
         
-        // Manual encoder / decoder functions are needed for Codable conformance AND Model macro
-        
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             keysetID = try container.decode(String.self, forKey: .keysetID)

--- a/Sources/cashu-swift/Models/Keyset.swift
+++ b/Sources/cashu-swift/Models/Keyset.swift
@@ -15,7 +15,7 @@ extension CashuSwift {
 
     public struct Keyset: Codable, Sendable {
         public let keysetID: String
-        public var keys: Dictionary<String, String>
+        public var keys: Dictionary<String, String> //FIXME: this should have an integer as key
         public var derivationCounter:Int
         public var active:Bool
         public let unit:String

--- a/Sources/cashu-swift/Models/Output.swift
+++ b/Sources/cashu-swift/Models/Output.swift
@@ -26,5 +26,12 @@ extension CashuSwift {
         public let id: String
         public let amount: Int
         public let C_: String
+        public let dleq: DLEQ?
+    }
+    
+    public struct DLEQ: Codable, Sendable {
+        public let e: String
+        public let s: String
+        public let r: String?
     }
 }

--- a/Sources/cashu-swift/Models/Proof.swift
+++ b/Sources/cashu-swift/Models/Proof.swift
@@ -19,13 +19,14 @@ extension CashuSwift {
         }
         
         public enum CodingKeys: String, CodingKey {
-            case keysetID = "id", amount, secret, C
+            case keysetID = "id", amount, secret, C, dleq
         }
         
         public let keysetID: String
         public let amount: Int
         public let secret: String
         public let C: String
+        public let dleq: DLEQ?
         
         public var description: String {
             return "C: ...\(C.suffix(6)), amount: \(amount)"
@@ -36,35 +37,36 @@ extension CashuSwift {
             self.C = proofRepresentation.C
             self.amount = proofRepresentation.amount
             self.secret = proofRepresentation.secret
+            #warning("patchwork: dleq must not be set to nil")
+            self.dleq = nil
         }
+                
+//        public func encode(to encoder: Encoder) throws {
+//            var container = encoder.container(keyedBy: CodingKeys.self)
+//            try container.encode(keysetID, forKey: .keysetID)
+//            try container.encode(amount, forKey: .amount)
+//            try container.encode(secret, forKey: .secret)
+//            try container.encode(C, forKey: .C)
+//        }
+//        
+//        public init(from decoder: Decoder) throws {
+//            let container = try decoder.container(keyedBy: CodingKeys.self)
+//            keysetID = try container.decode(String.self, forKey: .keysetID)
+//            amount = try container.decode(Int.self, forKey: .amount)
+//            secret = try container.decode(String.self, forKey: .secret)
+//            C = try container.decode(String.self, forKey: .C)
+//        }
         
-        // MARK: - Codable Implementation
-        
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(keysetID, forKey: .keysetID)
-            try container.encode(amount, forKey: .amount)
-            try container.encode(secret, forKey: .secret)
-            try container.encode(C, forKey: .C)
-        }
-        
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            keysetID = try container.decode(String.self, forKey: .keysetID)
-            amount = try container.decode(Int.self, forKey: .amount)
-            secret = try container.decode(String.self, forKey: .secret)
-            C = try container.decode(String.self, forKey: .C)
-        }
-        
-        public init(keysetID:String, amount:Int, secret:String, C:String) {
+        // TODO: remove default for dleq
+        public init(keysetID:String, amount:Int, secret:String, C:String, dleq: DLEQ? = nil) {
             self.keysetID = keysetID
             self.amount = amount
             self.secret = secret
             self.C = C
+            self.dleq = dleq
         }
         
         // MARK: - Additional nested types
-        
         public enum ProofState: String, Codable, Sendable {
             case unspent = "UNSPENT"
             case pending = "PENDING"

--- a/Sources/cashu-swift/Models/Proof.swift
+++ b/Sources/cashu-swift/Models/Proof.swift
@@ -37,8 +37,7 @@ extension CashuSwift {
             self.C = proofRepresentation.C
             self.amount = proofRepresentation.amount
             self.secret = proofRepresentation.secret
-            #warning("patchwork: dleq must not be set to nil")
-            self.dleq = nil
+            self.dleq = proofRepresentation.dleq
         }
                 
 //        public func encode(to encoder: Encoder) throws {

--- a/Sources/cashu-swift/Models/Protocols.swift
+++ b/Sources/cashu-swift/Models/Protocols.swift
@@ -20,5 +20,7 @@ public protocol ProofRepresenting/*: Codable, Equatable*/ {
     var C:String { get }
     var secret:String { get }
     var amount:Int { get }
+    
+    var dleq: CashuSwift.DLEQ? { get }
 }
 

--- a/Sources/cashu-swift/Models/Swap.swift
+++ b/Sources/cashu-swift/Models/Swap.swift
@@ -16,5 +16,4 @@ extension CashuSwift {
     struct SwapResponse: Codable {
         let signatures:[Promise]
     }
-
 }

--- a/Sources/cashu-swift/Models/Token.swift
+++ b/Sources/cashu-swift/Models/Token.swift
@@ -109,11 +109,25 @@ extension CashuSwift {
             let tokenEntries = try byKeysetID.map { (id, ps) in
                 TokenV4.TokenEntry(keysetID: Data(try id.bytes),
                                    proofs: try ps.map({ p in
-                    TokenV4.TokenEntry.Proof(amount: p.amount,
-                                             secret: p.secret,
-                                             signature: Data(try p.C.bytes),
-                                             dleqProof: nil,
-                                             witness: nil)
+                    
+                    let dleq: TokenV4.TokenEntry.Proof.DLEQProof?
+                    if let data = p.dleq,
+                       let r = data.r,
+                       let eBytes = try? data.e.bytes,
+                       let sBytes = try? data.s.bytes,
+                       let rBytes = try? r.bytes {
+                        dleq = TokenV4.TokenEntry.Proof.DLEQProof(e: Data(eBytes),
+                                                                  s: Data(sBytes),
+                                                                  r: Data(rBytes))
+                    } else {
+                        dleq = nil
+                    }
+                    
+                    return TokenV4.TokenEntry.Proof(amount: p.amount,
+                                                    secret: p.secret,
+                                                    signature: Data(try p.C.bytes),
+                                                    dleqProof: dleq,
+                                                    witness: nil)
                 }))
             }
             

--- a/Sources/cashu-swift/Models/Token.swift
+++ b/Sources/cashu-swift/Models/Token.swift
@@ -33,8 +33,8 @@ extension CashuSwift {
         }
         
         public init(proofs: [String: [any ProofRepresenting]],
-                   unit: String,
-                   memo: String? = nil) {
+                    unit: String,
+                    memo: String? = nil) {
             self.proofsByMint = proofs.mapValues { proofArray in
                 proofArray.map { proofRepresenting in
                     Proof(proofRepresenting)
@@ -57,12 +57,23 @@ extension CashuSwift {
             var ps = [Proof]()
             
             for entry in token.tokens {
+                
                 ps.append(contentsOf: entry.proofs.map({ p in
-                    Proof(keysetID: String(bytes: entry.keysetID),
-                          amount: p.amount,
-                          secret: p.secret,
-                          C: String(bytes: p.signature))
-                    // TODO: needs to take DLEQ data into account
+                    
+                    let dleq: CashuSwift.DLEQ?
+                    if let dleqFields = p.dleqProof {
+                        dleq = CashuSwift.DLEQ(e: String(bytes: dleqFields.e),
+                                               s: String(bytes: dleqFields.s),
+                                               r: String(bytes: dleqFields.r))
+                    } else {
+                        dleq = nil
+                    }
+                    
+                    return Proof(keysetID: String(bytes: entry.keysetID),
+                                 amount: p.amount,
+                                 secret: p.secret,
+                                 C: String(bytes: p.signature),
+                                 dleq: dleq)
                 }))
             }
             

--- a/Sources/cashu-swift/Operations/issue.swift
+++ b/Sources/cashu-swift/Operations/issue.swift
@@ -89,7 +89,7 @@ extension CashuSwift {
     
     public static func issue(for quote:Quote,
                              with mint: Mint,
-                             seed:String? = nil,
+                             seed:String?,
                              preferredDistribution:[Int]? = nil) async throws -> (proofs: [Proof], validDLEQ: Bool) {
         
         // TODO: completely remove issue function without dleq check
@@ -103,7 +103,7 @@ extension CashuSwift {
             dleqValid = try Crypto.validDLEQ(for: proofs, with: mint)
         } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
             logger.warning("""
-                           DLEQ check could not be performed due to missing data but will still \
+                           While restoring from mint \(mint.url) DLEQ check could not be performed due to missing data but will still \
                            evaluate as passing because not all wallets and mint support NUT-10. \
                            future versions will consider the check failed.
                            """)

--- a/Sources/cashu-swift/Operations/issue.swift
+++ b/Sources/cashu-swift/Operations/issue.swift
@@ -73,6 +73,8 @@ extension CashuSwift {
                                                 secrets: outputs.secrets,
                                                 keyset: activeKeyset)
         
+        // TODO: verify DLEQ
+        
         return proofs
     }
 

--- a/Sources/cashu-swift/Operations/issue.swift
+++ b/Sources/cashu-swift/Operations/issue.swift
@@ -98,7 +98,19 @@ extension CashuSwift {
                                      seed: seed,
                                      preferredDistribution: preferredDistribution)
         
-        let dleqValid = try Crypto.validDLEQ(for: proofs, with: mint)
+        let dleqValid: Bool
+        do {
+            dleqValid = try Crypto.validDLEQ(for: proofs, with: mint)
+        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
+            logger.warning("""
+                           DLEQ check could not be performed due to missing data but will still \
+                           evaluate as passing because not all wallets and mint support NUT-10. \
+                           future versions will consider the check failed.
+                           """)
+            dleqValid = true
+        } catch {
+            throw error
+        }
         
         return (proofs, dleqValid)
     }

--- a/Sources/cashu-swift/Operations/issue.swift
+++ b/Sources/cashu-swift/Operations/issue.swift
@@ -67,7 +67,7 @@ extension CashuSwift {
         let promises = try await Network.post(url: mint.url.appending(path: "/v1/mint/bolt11"),
                                               body: mintRequest,
                                               expected: Bolt11.MintResponse.self)
-                    
+                            
         let proofs = try Crypto.unblindPromises(promises.signatures,
                                                 blindingFactors: outputs.blindingFactors,
                                                 secrets: outputs.secrets,

--- a/Sources/cashu-swift/Operations/melt.swift
+++ b/Sources/cashu-swift/Operations/melt.swift
@@ -54,6 +54,8 @@ extension CashuSwift {
         
         let meltResponse:Bolt11.MeltQuote
         
+        #warning("ensure we do not send blindingfactor to mint in the dleq field")
+        
         meltResponse = try await Network.post(url: mint.url.appending(path: "/v1/melt/bolt11"),
                                               body: meltRequest,
                                               expected: Bolt11.MeltQuote.self,

--- a/Sources/cashu-swift/Operations/melt.swift
+++ b/Sources/cashu-swift/Operations/melt.swift
@@ -99,6 +99,7 @@ extension CashuSwift {
     ///Checks whether the invoice was successfully paid by the mint.
     ///If the check returns `true` and the user has provided NUT-07 blank outputs for fee return
     ///it will also unblind the mint's promises and return valid change proofs.
+    @available(*, deprecated, message: "function does not check DLEQ")
     public static func meltState(mint: MintRepresenting,
                                  quoteID: String,
                                  blankOutputs: (outputs: [Output],

--- a/Sources/cashu-swift/Operations/misc.swift
+++ b/Sources/cashu-swift/Operations/misc.swift
@@ -85,6 +85,16 @@ public enum CashuSwift {
         proofRepresenting.reduce(0) { $0 + $1.amount }
     }
     
+    static func stripDLEQ(_ proofs: [ProofRepresenting]) -> [CashuSwift.Proof] {
+        proofs.map { p in
+            CashuSwift.Proof(keysetID: p.keysetID,
+                             amount: p.amount,
+                             secret: p.secret,
+                             C: p.C,
+                             dleq: nil)
+        }
+    }
+    
     public static func pick(_ proofs: [ProofRepresenting],
                             amount: Int,
                             mint: MintRepresenting,
@@ -278,10 +288,6 @@ extension Array where Element : ProofRepresenting {
     
     public func pick(_ amount:Int) -> (picked:[ProofRepresenting], change:[ProofRepresenting])? {
         CashuSwift.selectProofsToSumTarget(proofs: self, targetAmount: amount)
-    }
-    
-    func internalize() -> [CashuSwift.Proof] {
-        map({ CashuSwift.Proof($0) })
     }
 }
 

--- a/Sources/cashu-swift/Operations/receive.swift
+++ b/Sources/cashu-swift/Operations/receive.swift
@@ -12,6 +12,8 @@ import OSLog
 fileprivate let logger = Logger.init(subsystem: "CashuSwift", category: "wallet")
 
 extension CashuSwift {
+    
+    @available(*, deprecated, message: "function does not check DLEQ")
     public static func receive(mint:MintRepresenting,
                                token:Token,
                                seed:String? = nil) async throws -> [ProofRepresenting] {
@@ -33,11 +35,33 @@ extension CashuSwift {
         return try await swap(mint:mint, proofs: inputProofs, seed: seed).new
     }
     
+    @available(*, deprecated, message: "function does not check DLEQ")
     public static func receive(mint: Mint,
                              token: Token,
                              seed: String? = nil) async throws -> [Proof] {
         return try await receive(mint: mint as MintRepresenting,
                                 token: token,
                                 seed: seed) as! [Proof]
+    }
+    
+    public static func receive(token: Token, with mint: Mint, seed: String?) async throws -> (proofs: [Proof], validDLEQ: Bool) {
+        
+        // this should check whether proofs are from this mint and not multi unit FIXME: potentially wonky and not very descriptive
+        guard token.proofsByMint.count == 1 else {
+            logger.error("You tried to receive a token that either contains no proofs at all, or proofs from more than one mint.")
+            throw CashuError.invalidToken
+        }
+        
+        if token.proofsByMint.keys.first! != mint.url.absoluteString {
+            logger.warning("Mint URL field from token does not seem to match this mints URL.")
+        }
+        
+        guard let inputProofs = token.proofsByMint.first?.value,
+              try units(for: inputProofs, of: mint).count == 1 else {
+            throw CashuError.unitError("Proofs to swap are either of mixed unit or foreign to this mint.")
+        }
+        
+        let swapResult = try await swap(with: mint, inputs: inputProofs, seed: seed)
+        return (swapResult.new, swapResult.validDLEQ)
     }
 }

--- a/Sources/cashu-swift/Operations/swap.swift
+++ b/Sources/cashu-swift/Operations/swap.swift
@@ -139,7 +139,7 @@ extension CashuSwift {
             inputsValidDLEQ = try Crypto.validDLEQ(for: inputs, with: mint)
         } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
             logger.warning("""
-                           DLEQ check could not be performed due to missing data but will still \
+                           Before swap: DLEQ check could not be performed due to missing data but will still \
                            evaluate as passing because not all wallets and mint support NUT-10. \
                            future versions will consider the check failed.
                            """)
@@ -165,7 +165,7 @@ extension CashuSwift {
             outputsValidDLEQ = try Crypto.validDLEQ(for: swapResult.new + swapResult.change, with: mint)
         } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
             logger.warning("""
-                           DLEQ check could not be performed due to missing data but will still \
+                           After swap: DLEQ check could not be performed due to missing data but will still \
                            evaluate as passing because not all wallets and mint support NUT-10. \
                            future versions will consider the check failed.
                            """)

--- a/Sources/cashu-swift/Operations/swap.swift
+++ b/Sources/cashu-swift/Operations/swap.swift
@@ -137,9 +137,15 @@ extension CashuSwift {
         let inputsValidDLEQ: Bool
         do {
             inputsValidDLEQ = try Crypto.validDLEQ(for: inputs, with: mint)
-        } catch {
-            // TODO: more precise error matching
+        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
+            logger.warning("""
+                           DLEQ check could not be performed due to missing data but will still \
+                           evaluate as passing because not all wallets and mint support NUT-10. \
+                           future versions will consider the check failed.
+                           """)
             inputsValidDLEQ = true
+        } catch {
+            throw error
         }
         
         // scrub dleq data before swap
@@ -154,7 +160,19 @@ extension CashuSwift {
                                         preferredReturnDistribution: preferredReturnDistribution)
         
         // check output proofs dleq
-        let outputsValidDLEQ = try Crypto.validDLEQ(for: swapResult.new + swapResult.change, with: mint)
+        let outputsValidDLEQ: Bool
+        do {
+            outputsValidDLEQ = try Crypto.validDLEQ(for: swapResult.new + swapResult.change, with: mint)
+        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
+            logger.warning("""
+                           DLEQ check could not be performed due to missing data but will still \
+                           evaluate as passing because not all wallets and mint support NUT-10. \
+                           future versions will consider the check failed.
+                           """)
+            outputsValidDLEQ = true
+        } catch {
+            throw error
+        }
         
         let validDLEQ = (inputsValidDLEQ && outputsValidDLEQ)
         

--- a/Sources/cashu-swift/Operations/swap.swift
+++ b/Sources/cashu-swift/Operations/swap.swift
@@ -85,6 +85,9 @@ extension CashuSwift {
                                                                  deterministicFactors: deterministicFactors)
         
         let internalProofs = normalize(proofs)
+        
+        #warning("ensure we do not send blindingfactor to mint in the dleq field")
+        
         let swapRequest = SwapRequest(inputs: internalProofs, outputs: outputs)
         let swapResponse = try await Network.post(url: mint.url.appending(path: "/v1/swap"),
                                                   body: swapRequest,

--- a/Sources/cashu-swift/Operations/swap.swift
+++ b/Sources/cashu-swift/Operations/swap.swift
@@ -137,7 +137,7 @@ extension CashuSwift {
         let inputsValidDLEQ: Bool
         do {
             inputsValidDLEQ = try Crypto.validDLEQ(for: inputs, with: mint)
-        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
+        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(_) {
             logger.warning("""
                            Before swap: DLEQ check could not be performed due to missing data but will still \
                            evaluate as passing because not all wallets and mint support NUT-10. \
@@ -148,13 +148,8 @@ extension CashuSwift {
             throw error
         }
         
-        // scrub dleq data before swap
-        let scrubbed = inputs.map { p in
-            Proof(keysetID: p.keysetID, amount: p.amount, secret: p.secret, C: p.C, dleq: nil)
-        }
-        
         let swapResult = try await swap(mint: mint,
-                                        proofs: scrubbed,
+                                        proofs: stripDLEQ(inputs), // Making sure no DLEQ data is submitted to the mint
                                         amount: amount,
                                         seed: seed,
                                         preferredReturnDistribution: preferredReturnDistribution)
@@ -163,7 +158,7 @@ extension CashuSwift {
         let outputsValidDLEQ: Bool
         do {
             outputsValidDLEQ = try Crypto.validDLEQ(for: swapResult.new + swapResult.change, with: mint)
-        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(let message) {
+        } catch CashuSwift.Crypto.Error.DLEQVerificationNoData(_) {
             logger.warning("""
                            After swap: DLEQ check could not be performed due to missing data but will still \
                            evaluate as passing because not all wallets and mint support NUT-10. \

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -382,6 +382,9 @@ final class cashu_swiftTests: XCTestCase {
         
         XCTAssertEqual(Array(proofs.dropFirst(2)), restoredProofs)
         XCTAssertEqual(Array(proofs.dropFirst(2)).sum, restoredProofs.sum)
+        
+        let (_, dleqValid) = try await CashuSwift.restore(from: mint, with: seed)
+        XCTAssertTrue(dleqValid)
     }
     
     func testFeeCalculation() async throws {
@@ -647,7 +650,7 @@ final class cashu_swiftTests: XCTestCase {
     func testDLEQAfterMinting() async throws {
         let mint = try await CashuSwift.loadMint(url: URL(string: dnsTestMint)!)
         let mintQuote = try await CashuSwift.getQuote(mint: mint, quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 3))
-        let result = try await CashuSwift.issue(for: mintQuote, with: mint)
+        let result = try await CashuSwift.issue(for: mintQuote, with: mint, seed: nil)
         
         XCTAssertTrue(result.validDLEQ)
     }
@@ -658,7 +661,7 @@ final class cashu_swiftTests: XCTestCase {
         
         let mintQuote = try await CashuSwift.getQuote(mint: mint, quoteRequest: qr)
         
-        let mintResult = try await CashuSwift.issue(for: mintQuote, with: mint, preferredDistribution: [1, 1, 1])
+        let mintResult = try await CashuSwift.issue(for: mintQuote, with: mint, seed: nil, preferredDistribution: [1, 1, 1])
         
         let swap1 = try await CashuSwift.swap(with: mint, inputs: [mintResult.proofs[0]], seed: nil)
         XCTAssertTrue(swap1.validDLEQ)
@@ -685,4 +688,5 @@ final class cashu_swiftTests: XCTestCase {
         let token = try "cashuBo2FteBtodHRwczovL3Rlc3RudXQuY2FzaHUuc3BhY2VhdWNzYXRhdIGiYWlIAJofKTJT5B5hcIGkYWEBYXN4QDcyMGVhMjcwYTQ4NDk0YThhNzMwM2E2YjczZTk5NDM1MTU1ZGFjMzFmYjIyYjg5YjllZjFmZGFlMzNjNmIzODVhY1ghAh9iiqwq9POuxIxSW8APMCT3Mw9d5bQv0uTZvUQow9V5YWSjYWVYIGMAHPJTvIcRDgIYcks-1CgWGCipn8QPxmrBvQRxA-RaYXNYICF1NnjVfZDs30T0TXUIORPbaNKkbYUI8vhUPJCxwCy6YXJYIE7keXw6yoxTzpgT_qGKJvWVrDP4NcCPAMlSMPY37LpO".deserializeToken()
         print(token.debugPretty())
     }
+
 }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -5,6 +5,8 @@ import secp256k1
 import BIP39
 import SwiftCBOR
 
+let dnsTestMint = "https://testmint.macadamia.cash"
+
 final class cashu_swiftTests: XCTestCase {
     
     func testSecretSerialization() throws {
@@ -642,4 +644,12 @@ final class cashu_swiftTests: XCTestCase {
         print(String(bytes: hash))
     }
     
+    func testDLEQAfterMinting() async throws {
+        let mint = try await CashuSwift.loadMint(url: URL(string: dnsTestMint)!)
+        let mintQuote = try await CashuSwift.getQuote(mint: mint, quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 21))
+        let proofs = try await CashuSwift.issue(for: mintQuote, on: mint)
+        
+        let dleq = try CashuSwift.Crypto.validDLEQ(for: proofs, with: mint)
+        XCTAssertTrue(dleq)
+    }
 }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -606,15 +606,29 @@ final class cashu_swiftTests: XCTestCase {
     func testDLEQverification() throws {
         
         let A = try secp256k1.Signing.PublicKey(dataRepresentation: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".bytes, format: .compressed)
-        let B_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
-        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
         
-        let e = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73d9".bytes)
-        let s = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73da".bytes)
+        do {
+            let B_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
+            let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
+            let e = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73d9".bytes)
+            let s = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73da".bytes)
+            
+            let result = try CashuSwift.Crypto.verifyDLEQ(A: A, B_: B_, C_: C_, e: e, s: s)
+            
+            XCTAssertTrue(result)
+        }
         
-        let result = try CashuSwift.Crypto.verifyDLEQ(A: A, B_: B_, C_: C_, e: e, s: s)
-        
-        XCTAssertTrue(result)
+        do {
+            let C = try secp256k1.Signing.PublicKey(dataRepresentation: "024369d2d22a80ecf78f3937da9d5f30c1b9f74f0c32684d583cca0fa6a61cdcfc".bytes, format: .compressed)
+            let x = "daf4dd00a2b68a0858a80450f52c8a7d2ccf87d375e43e216e0c571f089f63e9"
+            let r = try Data("a6d13fcd7a18442e6076f5e1e7c887ad5de40a019824bdfa9fe740d302e8d861".bytes)
+            let e = try Data("b31e58ac6527f34975ffab13e70a48b6d2b0d35abc4b03f0151f09ee1a9763d4".bytes)
+            let s = try Data("8fbae004c59e754d71df67e392b6ae4e29293113ddc2ec86592a0431d16306d8".bytes)
+            
+            let result = try CashuSwift.Crypto.verifyDLEQ(A: A, C: C, x: x, e: e, s: s, r: r)
+            
+            XCTAssertTrue(result)
+        }
     }
     
     func testHashConcat() throws {

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -606,13 +606,6 @@ final class cashu_swiftTests: XCTestCase {
         print(meltQuote.quote)
     }
     
-    func testKeyLenght() throws {
-        let sk = try secp256k1.Signing.PrivateKey()
-        let pk = try sk.publicKey.multiply(secp256k1.Signing.PrivateKey().publicKey.dataRepresentation.bytes, format: .uncompressed)
-        let pk2 = sk.publicKey
-        
-    }
-    
     func testDLEQverification() throws {
         
         let A = try secp256k1.Signing.PublicKey(dataRepresentation: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".bytes, format: .compressed)

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -615,9 +615,9 @@ final class cashu_swiftTests: XCTestCase {
     
     func testDLEQverification() throws {
         
-        let A = try secp256k1.Signing.PublicKey(dataRepresentation: "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8".bytes, format: .uncompressed)
-        let B_ = try secp256k1.Signing.PublicKey(dataRepresentation: "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68".bytes, format: .uncompressed)
-        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68".bytes, format: .uncompressed)
+        let A = try secp256k1.Signing.PublicKey(dataRepresentation: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".bytes, format: .compressed)
+        let B_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
+        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
         
         let e = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73d9".bytes)
         let s = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73da".bytes)
@@ -628,8 +628,8 @@ final class cashu_swiftTests: XCTestCase {
     }
     
     func testHashConcat() throws {
-        let k = try secp256k1.Signing.PublicKey(dataRepresentation: "0400000000000000000000000000000000000000000000000000000000000000014218f20ae6c646b363db68605822fb14264ca8d2587fdd6fbc750d587e76a7ee".bytes, format: .uncompressed)
-        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68".bytes, format: .uncompressed)
+        let k = try secp256k1.Signing.PublicKey(dataRepresentation: "020000000000000000000000000000000000000000000000000000000000000001".bytes, format: .compressed)
+        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes, format: .compressed)
         
         let hash = CashuSwift.Crypto.hashConcat([k, k, k, C_])
         

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -161,13 +161,8 @@ final class cashu_swiftTests: XCTestCase {
         let quote = try await CashuSwift.getQuote(mint: mint,
                                                   quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat",
                                                                                                    amount: amount))
-        let proofs = try await CashuSwift.issue(for: quote, on: mint) as! [CashuSwift.Proof]
-        
-        let token = CashuSwift.TokenV3(token: [CashuSwift.ProofContainer(mint: mint.url.absoluteString, proofs: proofs)])
-                
-        //        print(try token.serialize(.V3))
-        // (mew, change)
-
+        let proofs = try await CashuSwift.issue(for: quote, on: mint)
+        print(proofs.debugPretty())
         let (_, _) = try await CashuSwift.swap(mint: mint, proofs: proofs, amount: 300)
         
     }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -605,4 +605,37 @@ final class cashu_swiftTests: XCTestCase {
         
         print(meltQuote.quote)
     }
+    
+    func testKeyLenght() throws {
+        let sk = try secp256k1.Signing.PrivateKey()
+        let pk = try sk.publicKey.multiply(secp256k1.Signing.PrivateKey().publicKey.dataRepresentation.bytes, format: .uncompressed)
+        let pk2 = sk.publicKey
+        
+    }
+    
+    func testDLEQverification() throws {
+        
+        let A = try secp256k1.Signing.PublicKey(dataRepresentation: "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8".bytes, format: .uncompressed)
+        let B_ = try secp256k1.Signing.PublicKey(dataRepresentation: "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68".bytes, format: .uncompressed)
+        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68".bytes, format: .uncompressed)
+        
+        let e = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73d9".bytes)
+        let s = try Data("9818e061ee51d5c8edc3342369a554998ff7b4381c8652d724cdf46429be73da".bytes)
+        
+        let result = try CashuSwift.Crypto.verifyDLEQ(A: A, B_: B_, C_: C_, e: e, s: s)
+        
+        XCTAssertTrue(result)
+    }
+    
+    func testHashConcat() throws {
+        let k = try secp256k1.Signing.PublicKey(dataRepresentation: "0400000000000000000000000000000000000000000000000000000000000000014218f20ae6c646b363db68605822fb14264ca8d2587fdd6fbc750d587e76a7ee".bytes, format: .uncompressed)
+        let C_ = try secp256k1.Signing.PublicKey(dataRepresentation: "04a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba270b2031fef3acf8e13ea7a395e375491bdc37be1cd79e073d82bfd5ba8d35d68".bytes, format: .uncompressed)
+        
+        let hash = CashuSwift.Crypto.hashConcat([k, k, k, C_])
+        
+        XCTAssertEqual(String(bytes: hash), "a4dc034b74338c28c6bc3ea49731f2a24440fc7c4affc08b31a93fc9fbe6401e")
+        
+        print(String(bytes: hash))
+    }
+    
 }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -162,7 +162,9 @@ final class cashu_swiftTests: XCTestCase {
                                                   quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat",
                                                                                                    amount: amount))
         let proofs = try await CashuSwift.issue(for: quote, on: mint)
+        
         print(proofs.debugPretty())
+        
         let (_, _) = try await CashuSwift.swap(mint: mint, proofs: proofs, amount: 300)
         
     }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -677,5 +677,12 @@ final class cashu_swiftTests: XCTestCase {
         let inputRandomDLEQdata = Proof(keysetID: p3.keysetID, amount: p3.amount, secret: p3.secret, C: p3.C, dleq: wrongDLEQ)
         let swap3 = try await CashuSwift.swap(with: mint, inputs: [inputRandomDLEQdata], seed: nil)
         XCTAssertFalse(swap3.validDLEQ)
+        
+        
+    }
+    
+    func testTokenDeserializationWithDLEQ() throws {
+        let token = try "cashuBo2FteBtodHRwczovL3Rlc3RudXQuY2FzaHUuc3BhY2VhdWNzYXRhdIGiYWlIAJofKTJT5B5hcIGkYWEBYXN4QDcyMGVhMjcwYTQ4NDk0YThhNzMwM2E2YjczZTk5NDM1MTU1ZGFjMzFmYjIyYjg5YjllZjFmZGFlMzNjNmIzODVhY1ghAh9iiqwq9POuxIxSW8APMCT3Mw9d5bQv0uTZvUQow9V5YWSjYWVYIGMAHPJTvIcRDgIYcks-1CgWGCipn8QPxmrBvQRxA-RaYXNYICF1NnjVfZDs30T0TXUIORPbaNKkbYUI8vhUPJCxwCy6YXJYIE7keXw6yoxTzpgT_qGKJvWVrDP4NcCPAMlSMPY37LpO".deserializeToken()
+        print(token.debugPretty())
     }
 }

--- a/Tests/cashu-swiftTests/cashu_swiftTests.swift
+++ b/Tests/cashu-swiftTests/cashu_swiftTests.swift
@@ -287,26 +287,26 @@ final class cashu_swiftTests: XCTestCase {
     }
     
     func testMeltReal() async throws {
-//        let mint1 = try await Mint(with: URL(string: "https://mint.macadamia.cash")!)
-//        let mint2 = try await Mint(with: URL(string: "https://8333.space:3338")!)
-//        
-//        let mintQuote1 = try await mint1.getQuote(quoteRequest: Bolt11.RequestMintQuote(unit: "sat", amount: 128)) as! Bolt11.MintQuote
-//        print(mintQuote1.request)
-//        
-//        sleep(20)
-//        
-//        let proofs = try await mint1.issue(for: mintQuote1)
-//        
-//        let mintQuote2 = try await mint2.getQuote(quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 64)) as! Bolt11.MintQuote
-//        
-//        let meltQuote = try await mint1.getQuote(quoteRequest: CashuSwift.Bolt11.RequestMeltQuote(unit: "sat", request: mintQuote2.request, options: nil)) as! Bolt11.MeltQuote
-//        
-//        let mnemmonic = Mnemonic()
-//        let seed = String(bytes: mnemmonic.seed)
-//        
-//        let meltResult = try await mint1.melt(quote: meltQuote, proofs: proofs)
-//        print(meltResult)
-//        print(meltResult.change.sum)
+        
+        let mint1 = try await CashuSwift.loadMint(url: URL(string: "https://mint.macadamia.cash")!)
+        let mint2 = try await CashuSwift.loadMint(url: URL(string: "https://8333.space:3338")!)
+        
+        let mintQuote1 = try await CashuSwift.getQuote(mint: mint1, quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 128)) as! CashuSwift.Bolt11.MintQuote
+        print(mintQuote1.request)
+        
+        sleep(20)
+        
+        let mintResult = try await CashuSwift.issue(for: mintQuote1, with: mint1, seed: nil)
+        
+        let mintQuote2 = try await CashuSwift.getQuote(mint: mint2, quoteRequest: CashuSwift.Bolt11.RequestMintQuote(unit: "sat", amount: 64)) as! CashuSwift.Bolt11.MintQuote
+        
+        let meltQuote = try await CashuSwift.getQuote(mint: mint1, quoteRequest: CashuSwift.Bolt11.RequestMeltQuote(unit: "sat", request: mintQuote2.request, options: nil)) as! CashuSwift.Bolt11.MeltQuote
+        let blankOutputs = try CashuSwift.generateBlankOutputs(quote: meltQuote, proofs: mintResult.proofs, mint: mint1, unit: "sat")
+        
+        let meltResult = try await CashuSwift.melt(with: meltQuote, mint: mint1, proofs: mintResult.proofs, blankOutputs: blankOutputs)
+        
+        print(meltResult)
+        print(meltResult.change?.sum ?? "no change")
     }
     
     func testBlankOutputCalculation() {
@@ -576,21 +576,6 @@ final class cashu_swiftTests: XCTestCase {
     func testCreateRandomPubkey() {
         let priv = try! secp256k1.Signing.PrivateKey()
         print(String(bytes: priv.publicKey.dataRepresentation))
-    }
-    
-    func testMultiReceive() async throws {
-//        let mint1 = try await CashuSwift.loadMint(url: URL(string: "https://testmint.macadamia.cash")!)
-//        let mint2 = try await CashuSwift.loadMint(url: URL(string: "https://testnut.cashu.space")!)
-//        
-//        let mints = [mint1, mint2]
-//        
-//        let mmt = "cashuAeyJtZW1vIjoiV2FsbGV0IERyYWluIiwidG9rZW4iOlt7Im1pbnQiOiJodHRwczpcL1wvdGVzdG51dC5jYXNodS5zcGFjZSIsInByb29mcyI6W3sic2VjcmV0IjoiMDAyYmU3NGIwNzQ5NDBlN2Y5N2VkMWZmMzRlMTVlMTkyM2I1ODMzZmY0NjhjMDU0YzFiMjA3ODZmYzZmOTEwYSIsImFtb3VudCI6MSwiaWQiOiIwMDlhMWYyOTMyNTNlNDFlIiwiQyI6IjAyOTg5NWQ0N2MyMWZjM2M3ZDQwOGQ4MGQ5ZmVlYjMzNDJjYWQ1MjY5ZjQ5MTRkZjBiMTE1N2Q1ZjMxNTgwZDIwNCJ9LHsiYW1vdW50Ijo0LCJpZCI6IjAwOWExZjI5MzI1M2U0MWUiLCJzZWNyZXQiOiIyMmZmMTM2MzJlMjM1ODRiY2Y4MWE4ZTAxNGQ5ZmQ4MmY2OGNhZTFhZGQzZmRkOGM4ZDk4NGY1ZWI4NjQ2ZTNjIiwiQyI6IjAzNWRkYjBlODhjNWFlZmNjYTAyNDZkODQzNmY2YTAxYWU0OTE2Yjk3ZTNkZTNmOGY3YzQ0MDIyODcyYzhhZjg0MCJ9LHsiaWQiOiIwMDlhMWYyOTMyNTNlNDFlIiwiYW1vdW50IjoxNiwiQyI6IjAzYjBiZmIzNWU0OGI1YmUxNmM4MGM3NGY3NTgyZDgzMjNlNmJkM2E3N2M1ZWY1ZmE4NjY3MDIwNThiNWViOGViYyIsInNlY3JldCI6Ijg3NzEzYjRhN2I0ZDcxMmY3Njc0M2IyODQ5NTQ3NjkxNDQ0M2U1YmExOGExZDIxMWM0NzU3Y2I3NmE1M2YwNWIifV19LHsibWludCI6Imh0dHBzOlwvXC90ZXN0bWludC5tYWNhZGFtaWEuY2FzaCIsInByb29mcyI6W3siQyI6IjAzMzVmYWFhZmE0ODgxNjI4M2IyM2U2YjNjNDRmODU2NDcwZmE1ZjgwMzdkNDg2OGNmNDkwNDY2MmRhYWE5NDRjMCIsImFtb3VudCI6Miwic2VjcmV0IjoiYWNlYWU0MzNiNTJhNGFjZWNiNWYyMTFiMzkwNTc4OTljZTlkMTBkY2I0MDM3YzUyZjIxNzNjMTljNTdiZGZiYiIsImlkIjoiMDBlYTBkNDE2NjQ0MTI4YyJ9LHsiYW1vdW50Ijo4LCJzZWNyZXQiOiI4N2Y4MWRiNGVkMmFiNWIzYjMwMjQxNTJmZjg2MzIzZThiMWMyYTM5MzI5MzI4MTBlMTVjODI5YWJkMmUwYTZjIiwiaWQiOiIwMGVhMGQ0MTY2NDQxMjhjIiwiQyI6IjAzZmU0YjRhZDIzNGY5MzI1YjA4MDIxMjcwMjBlY2IzNDg1MGJhZWIzNmZlZmEzZmE0MjFlZjc4M2M0MzA4YWE3NiJ9LHsic2VjcmV0IjoiYjEwYmFiZmZhZDhkZmNkYWQzZTkwYmE4MmI4ZWRiMGMxZTNjNGE5MDlmMjNmOWY2MGRmOTczMjRiMzg4YzJlMiIsImFtb3VudCI6MzIsImlkIjoiMDBlYTBkNDE2NjQ0MTI4YyIsIkMiOiIwMjJjNGI5MGIxNTc5M2RmNDJjMTIxMTUyNjM4NTBiNmE2MzRmNzBkMzZmNzljODc4MDlmYzgwNjRmNTM4OTlmNWMifV19XX0="
-//        
-//        let token = try mmt.deserializeToken()
-//        
-//        let receivedProofs = try await mints.receive(token: token)
-//        
-//        print(receivedProofs)
     }
     
     func testMeltQuoteState() async throws {


### PR DESCRIPTION
This PR adds the capability to do DLEQ verification for ecash proofs after minting/swapping or before receiving from another user.
This allows a wallet to:
- Prevent tracking attempts from the mint
- Prevent fraudulent token redemption after receiving from a third party in general, or, in case of receiving locked ecash

See [NUT-12](https://github.com/cashubtc/nuts/blob/main/12.md)