### PR TITLE
Add Lightning invoice decoders

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,11 @@ let package = Package(
         .package(url: "https://github.com/pengpengliu/BIP39.git",
                  exact: "1.0.1"),
         .package(url: "https://github.com/myfreeweb/SwiftCBOR.git",
-                 from: "0.4.4")
+                 from: "0.4.4"),
+        .package(url: "https://github.com/zeugmaster/Bolt11.git",
+                 exact: "0.1.3"),
+        .package(url: "https://github.com/zeugmaster/Bolt12.git",
+                 exact: "0.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -39,7 +43,9 @@ let package = Package(
                 .product(name: "BIP32", package: "BIP32"),
                 .product(name: "BigNumber", package: "Swift-BigInt"),
                 .product(name: "BIP39", package: "BIP39"),
-                .product(name: "SwiftCBOR", package: "SwiftCBOR")
+                .product(name: "SwiftCBOR", package: "SwiftCBOR"),
+                .product(name: "Bolt11", package: "Bolt11"),
+                .product(name: "Bolt12", package: "Bolt12")
             ],
             swiftSettings: [
               .enableExperimentalFeature("StrictConcurrency")

--- a/Sources/cashu-swift/Models/PaymentMethods/Bolt11.swift
+++ b/Sources/cashu-swift/Models/PaymentMethods/Bolt11.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Bolt11
 
 extension CashuSwift {
     /// BOLT11 (Lightning invoice) payment method per NUT-23.
@@ -231,6 +232,17 @@ extension CashuSwift {
 
         /// Parses a BOLT11 invoice and returns its amount in satoshis (0 if the invoice is amountless).
         public static func satAmount(from invoice: String) throws -> Int {
+            do {
+                guard let millisatoshis = try Bolt11Decoder.decode(invoice).amountMillisatoshis else {
+                    return 0
+                }
+                return Int(millisatoshis / 1_000)
+            } catch {
+                return try satAmountFromHumanReadablePart(invoice)
+            }
+        }
+
+        private static func satAmountFromHumanReadablePart(_ invoice: String) throws -> Int {
             let lower = invoice.lowercased()
             guard let range = lower.range(of: "1", options: .backwards) else {
                 throw CashuError.bolt11InvalidInvoiceError("")
@@ -238,7 +250,7 @@ extension CashuSwift {
             let endIndex = range.lowerBound
             let hrp = String(lower[..<endIndex])
 
-            var prefixLength: Int = 0
+            let prefixLength: Int
             if hrp.hasPrefix("lnbcrt") {
                 prefixLength = 6
             } else if hrp.hasPrefix("lntbs") {

--- a/Sources/cashu-swift/Operations/LightningDecoding.swift
+++ b/Sources/cashu-swift/Operations/LightningDecoding.swift
@@ -1,0 +1,152 @@
+//
+//  LightningDecoding.swift
+//  CashuSwift
+//
+
+import Foundation
+import Bolt11
+import Bolt12
+
+extension CashuSwift {
+    public enum LightningRequest {
+        case bolt11Invoice(Invoice)
+        case bolt12Offer(Bolt12Offer)
+        case bolt12InvoiceRequest(Bolt12InvoiceRequest)
+        case bolt12Invoice(Bolt12Invoice)
+    }
+
+    /// Decodes a Lightning payment string as either BOLT11 or BOLT12.
+    ///
+    /// `lightning:` URI prefixes are accepted. BOLT12 continuation separators
+    /// are handled by the Bolt12 decoder.
+    public static func decodeLightningRequest(_ string: String) throws -> LightningRequest {
+        let payload = lightningPayloadString(string)
+        let prefix = compactLightningPrefix(payload)
+
+        if prefix.hasPrefix("lnbc") ||
+            prefix.hasPrefix("lntb") ||
+            prefix.hasPrefix("lntbs") ||
+            prefix.hasPrefix("lnbcrt") {
+            return .bolt11Invoice(try decodeBolt11Invoice(payload))
+        }
+
+        if prefix.hasPrefix("lno1") || prefix.hasPrefix("lnr1") || prefix.hasPrefix("lni1") {
+            let message = try decodeBolt12Message(payload)
+            switch message.kind {
+            case .offer:
+                guard let offer = message.offer else {
+                    throw CashuError.unsupportedPaymentMethod("Could not decode BOLT12 offer.")
+                }
+                return .bolt12Offer(offer)
+            case .invoiceRequest:
+                guard let invoiceRequest = message.invoiceRequest else {
+                    throw CashuError.unsupportedPaymentMethod("Could not decode BOLT12 invoice request.")
+                }
+                return .bolt12InvoiceRequest(invoiceRequest)
+            case .invoice:
+                guard let invoice = message.invoice else {
+                    throw CashuError.unsupportedPaymentMethod("Could not decode BOLT12 invoice.")
+                }
+                return .bolt12Invoice(invoice)
+            }
+        }
+
+        throw CashuError.unsupportedPaymentMethod("Unsupported Lightning request prefix.")
+    }
+
+    /// Decodes and validates a BOLT11 invoice.
+    public static func decodeBolt11Invoice(_ invoice: String) throws -> Invoice {
+        do {
+            return try Bolt11Decoder.decode(lightningPayloadString(invoice))
+        } catch {
+            throw CashuError.bolt11InvalidInvoiceError(error.localizedDescription)
+        }
+    }
+
+    /// Decodes a BOLT12 offer, invoice request, or invoice.
+    public static func decodeBolt12Message(_ string: String) throws -> Bolt12Message {
+        do {
+            return try Bolt12Decoder.decode(string)
+        } catch {
+            throw CashuError.unsupportedPaymentMethod(error.localizedDescription)
+        }
+    }
+
+    private static func lightningPayloadString(_ string: String) -> String {
+        var payload = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        if payload.lowercased().hasPrefix("lightning:") {
+            payload.removeFirst("lightning:".count)
+        }
+        return payload
+    }
+
+    private static func compactLightningPrefix(_ string: String) -> String {
+        var result = ""
+        for character in string {
+            if character == "+" || character.isWhitespace {
+                continue
+            }
+            result.append(character.lowercased())
+            if result.count >= 6 {
+                break
+            }
+        }
+        return result
+    }
+}
+
+extension CashuSwift.Bolt11.MintQuote {
+    /// Decoded Lightning invoice returned by the mint for this mint quote.
+    public var decodedInvoice: Invoice {
+        get throws {
+            try CashuSwift.decodeBolt11Invoice(request)
+        }
+    }
+}
+
+extension CashuSwift.Bolt11.MeltQuoteRequest {
+    /// Decoded Lightning invoice the mint is being asked to pay.
+    public var decodedInvoice: Invoice {
+        get throws {
+            try CashuSwift.decodeBolt11Invoice(request)
+        }
+    }
+}
+
+extension CashuSwift.Bolt11.MeltQuote {
+    /// Decoded Lightning invoice for this melt quote, when the mint echoed it.
+    public var decodedInvoice: Invoice? {
+        get throws {
+            guard let request else { return nil }
+            return try CashuSwift.decodeBolt11Invoice(request)
+        }
+    }
+}
+
+extension CashuSwift.Bolt12.MintQuote {
+    /// Decoded BOLT12 offer returned by the mint for this mint quote.
+    public var decodedOffer: Bolt12Offer {
+        get throws {
+            try Bolt12Decoder.decodeOffer(request)
+        }
+    }
+}
+
+extension CashuSwift.Bolt12.MeltQuoteRequest {
+    /// Decoded BOLT12 offer, invoice request, or invoice the mint is being asked to pay.
+    public var decodedRequest: Bolt12Message {
+        get throws {
+            try CashuSwift.decodeBolt12Message(request)
+        }
+    }
+}
+
+extension CashuSwift.Bolt12.MeltQuote {
+    /// Decoded BOLT12 payload for this melt quote, when the mint echoed it.
+    public var decodedRequest: Bolt12Message? {
+        get throws {
+            guard let request else { return nil }
+            return try CashuSwift.decodeBolt12Message(request)
+        }
+    }
+}

--- a/Tests/cashu-swiftTests/UnitTests.swift
+++ b/Tests/cashu-swiftTests/UnitTests.swift
@@ -22,6 +22,37 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(try CashuSwift.Bolt11.satAmount(from: invoice.uppercased()), 100)
     }
 
+    func testDecodeLightningRequestBolt11() throws {
+        let invoice = "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh"
+
+        let decoded = try CashuSwift.decodeLightningRequest("lightning:\(invoice)")
+
+        guard case let .bolt11Invoice(bolt11) = decoded else {
+            return XCTFail("Expected a BOLT11 invoice")
+        }
+        XCTAssertEqual(bolt11.amountMillisatoshis, 250_000_000)
+        XCTAssertEqual(bolt11.invoiceDescription, "1 cup coffee")
+    }
+
+    func testDecodeLightningRequestBolt12Offer() throws {
+        let nodeID = Data([0x02] + Array(repeating: 0x11, count: 32))
+        let offerBytes = bolt12TLV([
+            (8, Data([0x03, 0xe8])),
+            (10, Data("coffee".utf8)),
+            (22, nodeID)
+        ])
+        let encoded = encodeBolt12(hrp: "lno", bytes: offerBytes)
+
+        let decoded = try CashuSwift.decodeLightningRequest(encoded)
+
+        guard case let .bolt12Offer(offer) = decoded else {
+            return XCTFail("Expected a BOLT12 offer")
+        }
+        XCTAssertEqual(offer.amount, 1_000)
+        XCTAssertEqual(offer.description, "coffee")
+        XCTAssertEqual(offer.issuerID, nodeID)
+    }
+
     func testSecretSerialization() throws {
         
         // test that deserialization from string works properly
@@ -334,6 +365,67 @@ final class UnitTests: XCTestCase {
         
         XCTAssertEqual(expectedSecrets, outputs.secrets)
         XCTAssertEqual(expBF, outputs.blindingFactors)
+    }
+
+    private func bolt12TLV(_ records: [(UInt64, Data)]) -> Data {
+        var result = Data()
+        for (type, value) in records {
+            result.append(bigSize(type))
+            result.append(bigSize(UInt64(value.count)))
+            result.append(value)
+        }
+        return result
+    }
+
+    private func bigSize(_ value: UInt64) -> Data {
+        if value < 0xfd {
+            return Data([UInt8(value)])
+        }
+        if value <= 0xffff {
+            return Data([0xfd, UInt8(value >> 8), UInt8(value)])
+        }
+        if value <= 0xffff_ffff {
+            return Data([0xfe, UInt8(value >> 24), UInt8(value >> 16), UInt8(value >> 8), UInt8(value)])
+        }
+        return Data([
+            0xff,
+            UInt8(value >> 56),
+            UInt8(value >> 48),
+            UInt8(value >> 40),
+            UInt8(value >> 32),
+            UInt8(value >> 24),
+            UInt8(value >> 16),
+            UInt8(value >> 8),
+            UInt8(value)
+        ])
+    }
+
+    private func encodeBolt12(hrp: String, bytes: Data) -> String {
+        let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+        let words = convertBits(data: Array(bytes), fromBits: 8, toBits: 5, pad: true)
+        return hrp + "1" + String(words.map { charset[Int($0)] })
+    }
+
+    private func convertBits(data: [UInt8], fromBits: Int, toBits: Int, pad: Bool) -> [UInt8] {
+        var accumulator: UInt32 = 0
+        var bits = 0
+        var result: [UInt8] = []
+        let maxValue = UInt32((1 << toBits) - 1)
+
+        for value in data {
+            accumulator = (accumulator << fromBits) | UInt32(value)
+            bits += fromBits
+            while bits >= toBits {
+                bits -= toBits
+                result.append(UInt8((accumulator >> bits) & maxValue))
+            }
+        }
+
+        if pad, bits > 0 {
+            result.append(UInt8((accumulator << (toBits - bits)) & maxValue))
+        }
+
+        return result
     }
 
 }


### PR DESCRIPTION
## Summary
- add CashuSwift decoding helpers for BOLT11 invoices and BOLT12 offers/invoice requests/invoices
- depend on released Bolt11 0.1.3 and Bolt12 0.1.0 packages
- keep existing Bolt11 satAmount behavior compatible while validating via Bolt11 when possible

## Verification
- swift test --filter UnitTests

## Related package releases
- Bech32Swift 1.0.1
- Bolt11 v0.1.3
- Bolt12 v0.1.0