### PR TITLE
Add fee-aware proof selection

### DIFF
--- a/Sources/cashu-swift/Operations/PaymentRequestOperations.swift
+++ b/Sources/cashu-swift/Operations/PaymentRequestOperations.swift
@@ -121,33 +121,4 @@ extension CashuSwift {
         let bytes = (0..<4).map { _ in UInt8.random(in: 0...255) }
         return bytes.map { String(format: "%02x", $0) }.joined()
     }
-    
-    /// Generates a random nonce for spending conditions.
-    private static func generateRandomNonce() -> String {
-        let bytes = (0..<32).map { _ in UInt8.random(in: 0...255) }
-        return bytes.map { String(format: "%02x", $0) }.joined()
-    }
-    
-    /// Selects proofs to cover a specific amount.
-    private static func selectProofs(from proofs: [Proof], amount: Int) throws -> [Proof] {
-        var selected: [Proof] = []
-        var total = 0
-        
-        // Sort proofs by amount (smallest first for better selection)
-        let sortedProofs = proofs.sorted { $0.amount < $1.amount }
-        
-        for proof in sortedProofs {
-            if total >= amount {
-                break
-            }
-            selected.append(proof)
-            total += proof.amount
-        }
-        
-        guard total >= amount else {
-            throw CashuError.insufficientInputs("Cannot select enough proofs to cover amount \(amount)")
-        }
-        
-        return selected
-    }
 }

--- a/Sources/cashu-swift/Operations/ProofSelection.swift
+++ b/Sources/cashu-swift/Operations/ProofSelection.swift
@@ -1,0 +1,582 @@
+//
+//  ProofSelection.swift
+//  CashuSwift
+//
+//  Fee-aware ecash proof selection — a single, self-contained selector that
+//  chooses which existing proofs a wallet should spend for a given operation.
+//
+//  Design goals:
+//
+//    * Generic & identity-preserving ("select in place"). `selectProofs` is
+//      generic over any `ProofRepresenting`; the result's `selected` array
+//      holds the *caller's own* proof values (a subset of the input), never
+//      copies. A dependent wallet never converts to/from `CashuSwift.Proof`.
+//      The dynamic program runs entirely on integers and original indices, so
+//      the concrete proof type is read only at the boundary — no existentials,
+//      no downcasts, and no added `Hashable`/`Equatable` requirement on
+//      `ProofRepresenting`.
+//
+//    * Pure & deterministic. No networking, crypto, or randomness. The caller
+//      refreshes keysets, reserves proofs, and performs the swap/melt. Given
+//      the same request + policy seed the result is identical.
+//
+//    * Exact. Direct (fee-free) sends use exact subset-sum DP; mint
+//      transactions use a fee-aware Pareto bounded-knapsack that is provably
+//      optimal under the documented comparator unless `policy.maxStates` is hit
+//      (in which case optimality is reported truthfully).
+//
+//  NUT-02 input fees: fee(S) = ceil( Σ inputFeePPK(S) / 1000 ), paid only when
+//  a mint transaction (swap/melt/receive/…) is required — never for a direct
+//  token send of existing proofs.
+//
+
+import Foundation
+import CryptoKit
+
+extension CashuSwift {
+
+    // MARK: - Public API
+
+    /// Why proofs are being selected. Determines whether a zero-fee *direct*
+    /// send of existing proofs is acceptable, or whether a fee-bearing *mint
+    /// transaction* (swap/melt/…) is required.
+    public enum ProofSelectionPurpose: Sendable, Equatable {
+        case tokenTransferUnlocked
+        case tokenTransferLocked
+        case paymentRequest
+        case swap
+        case melt
+        case receive
+        case maintenanceRotation
+
+        /// Whether an exact, fee-free subset of existing proofs may satisfy the
+        /// request. Only an unlocked direct transfer can be fulfilled without a
+        /// mint transaction; every other purpose mints new outputs and pays the
+        /// NUT-02 input fee.
+        var allowsDirectExact: Bool { self == .tokenTransferUnlocked }
+    }
+
+    /// Tunable selection behaviour. Defaults match the wallet policy from the
+    /// implementation plan: prefer exact direct sends, then minimise actual fee,
+    /// change, proof count, and raw amount, then keyset hygiene, then a stable
+    /// deterministic tie-break.
+    public struct ProofSelectionPolicy: Sendable {
+        /// Try an exact, fee-free direct subset before fee-aware selection
+        /// (only consulted for purposes whose `allowsDirectExact` is true).
+        public var preferDirectExact: Bool
+        /// For mint transactions, break otherwise-equal candidates by spending
+        /// *inactive* keysets first (keyset hygiene). Never overrides
+        /// fee/change/count/amount.
+        public var preferInactiveKeysetsForMintTransactions: Bool
+        /// For direct sends, break otherwise-equal candidates by keeping the
+        /// recipient on *active* keysets. Never overrides proof-count/fee order.
+        public var avoidInactiveKeysetsForDirectSend: Bool
+        /// Guardrail on the fee-aware open-state count. `nil` disables the cap.
+        public var maxStates: Int?
+        /// When the state cap is hit: return the best feasible result found so
+        /// far (`true`) or throw `.stateLimitExceeded` (`false`).
+        public var bestEffortWhenStateLimitHit: Bool
+        /// Stable per-request entropy for deterministic tie-breaking. Never
+        /// serialized into tokens or sent to the mint. Empty ⇒ fixed ordering
+        /// (handy for tests); supply randomness to rotate which equal-shaped
+        /// proofs get spent over time.
+        public var randomSeed: Data
+
+        public init(preferDirectExact: Bool = true,
+                    preferInactiveKeysetsForMintTransactions: Bool = false,
+                    avoidInactiveKeysetsForDirectSend: Bool = false,
+                    maxStates: Int? = 200_000,
+                    bestEffortWhenStateLimitHit: Bool = false,
+                    randomSeed: Data = Data()) {
+            self.preferDirectExact = preferDirectExact
+            self.preferInactiveKeysetsForMintTransactions = preferInactiveKeysetsForMintTransactions
+            self.avoidInactiveKeysetsForDirectSend = avoidInactiveKeysetsForDirectSend
+            self.maxStates = maxStates
+            self.bestEffortWhenStateLimitHit = bestEffortWhenStateLimitHit
+            self.randomSeed = randomSeed
+        }
+
+        public static let `default` = ProofSelectionPolicy()
+    }
+
+    /// Whether the result is a direct token send (no mint interaction) or a
+    /// mint transaction (swap/melt) the caller must execute.
+    public enum ProofSelectionKind: Sendable, Equatable { case directToken, mintTransaction }
+
+    /// Whether the selection is mathematically proven optimal under the
+    /// comparator, or a best-effort result returned because the state cap hit.
+    public enum ProofSelectionOptimality: Sendable, Equatable { case provedOptimal, bestEffortStateLimitHit }
+
+    /// Result of a selection.
+    ///
+    /// `selected` are the *caller's own* proof values — a subset of the array
+    /// passed to `selectProofs`, never reconstructed — so a dependent wallet
+    /// can reserve/spend them by identity without any type conversion.
+    public struct ProofSelectionResult<P: ProofRepresenting> {
+        public let kind: ProofSelectionKind
+        /// The chosen proofs, a subset of the caller's input (ascending input order).
+        public let selected: [P]
+        /// NUT-02 input fee for `selected` (0 for a direct token send).
+        public let inputFee: Int
+        /// `Σ selected.amount − inputFee`.
+        public let netAmount: Int
+        /// `netAmount − targetAmount` (0 for a direct token send).
+        public let changeAmount: Int
+        /// Denomination split for the send/payment outputs (empty for direct).
+        public let sendOutputAmounts: [Int]
+        /// Denomination split for the change outputs (empty for direct / no change).
+        public let changeOutputAmounts: [Int]
+        /// NUT-08 blank-output amounts. Always empty here: melt callers size
+        /// blanks via `generateBlankOutputs(quote:proofs:…)` from `selected`,
+        /// reusing the library's vetted overpaid-fee-return logic rather than
+        /// duplicating it (the selector does not know `quote.amount`).
+        public let blankOutputAmounts: [Int]
+        /// Keysets the selected proofs are drawn from.
+        public let keysetIDsSpent: Set<String>
+        public let optimality: ProofSelectionOptimality
+    }
+
+    public enum ProofSelectionError: Error, Sendable {
+        /// No subset of eligible proofs can reach the target. Diagnostics avoid
+        /// leaking secrets.
+        case insufficientFunds(eligibleRawAmount: Int, requiredTarget: Int, purpose: ProofSelectionPurpose)
+        /// Every input was filtered out (wrong unit, locked, zero-amount, …).
+        case noEligibleProofs
+        /// A proof's keyset could not be resolved against the provided mint —
+        /// likely stale keyset data. The caller should refresh keysets and
+        /// retry. Unknown fee info is never silently treated as 0.
+        case missingKeysetInformation(keysetID: String)
+        /// The fee-aware search exceeded `policy.maxStates` and best-effort
+        /// fallback was disabled.
+        case stateLimitExceeded
+        /// `targetAmount` was negative.
+        case invalidTarget
+        case unsupportedPurpose(ProofSelectionPurpose)
+    }
+
+    /// Selects which existing proofs to spend for `purpose`.
+    ///
+    /// Identity-preserving: returns the caller's own `P` values (see
+    /// `ProofSelectionResult.selected`).
+    ///
+    /// - Parameters:
+    ///   - proofs: Candidate proofs. The wallet should pass unreserved proofs
+    ///     for this `mint`/`unit`; reservation/concurrency is the caller's job.
+    ///   - targetAmount: Amount to send/pay. For melt, pass
+    ///     `quote.amount + feeReserve`; the selector's `net ≥ target` invariant
+    ///     reproduces `Σ ≥ amount + feeReserve + inputFee`.
+    ///   - mint: Source of per-keyset fee rates and active/inactive status.
+    ///   - unit: The unit being spent (e.g. `"sat"`).
+    ///   - purpose: Drives direct-vs-mint-transaction behaviour.
+    ///   - policy: Tie-breaking knobs and guardrails.
+    /// - Returns: A `ProofSelectionResult` over the caller's proof type.
+    /// - Throws: `ProofSelectionError` on infeasible / invalid / stale-keyset input.
+    public static func selectProofs<P: ProofRepresenting>(
+        _ proofs: [P],
+        targetAmount: Int,
+        mint: some MintRepresenting,
+        unit: String,
+        purpose: ProofSelectionPurpose,
+        policy: ProofSelectionPolicy = .default
+    ) throws -> ProofSelectionResult<P> {
+
+        guard targetAmount >= 0 else { throw ProofSelectionError.invalidTarget }
+
+        let eligible = try eligibleProofs(proofs, mint: mint, unit: unit, seed: policy.randomSeed)
+        guard !eligible.isEmpty else { throw ProofSelectionError.noEligibleProofs }
+
+        if targetAmount == 0 {
+            return ProofSelectionResult(kind: .directToken, selected: [], inputFee: 0,
+                                        netAmount: 0, changeAmount: 0, sendOutputAmounts: [],
+                                        changeOutputAmounts: [], blankOutputAmounts: [],
+                                        keysetIDsSpent: [], optimality: .provedOptimal)
+        }
+
+        // Stage 1 — exact, fee-free direct subset.
+        if purpose.allowsDirectExact && policy.preferDirectExact {
+            let directItems = bundle(eligible,
+                                     scoreForActive: directScorer(policy),
+                                     dropFeeDominated: false)
+            if let state = exactDirectSubset(directItems, target: targetAmount) {
+                return directResult(state, items: directItems, proofs: proofs, target: targetAmount)
+            }
+        }
+
+        // Stage 2 — fee-aware bounded knapsack (mint transaction).
+        let mintItems = bundle(eligible,
+                               scoreForActive: mintScorer(policy),
+                               dropFeeDominated: true)
+        let eligibleRaw = eligible.reduce(0) { $0 + $1.amount }
+        let outcome = try feeAwareSubset(mintItems, target: targetAmount, policy: policy,
+                                         eligibleRawAmount: eligibleRaw, purpose: purpose)
+        return mintResult(outcome.state, optimality: outcome.optimality,
+                          items: mintItems, proofs: proofs, target: targetAmount, purpose: purpose)
+    }
+
+    // MARK: - Eligibility & keyset resolution
+
+    private struct EligibleProof {
+        let index: Int        // original index into the caller's array
+        let amount: Int
+        let ppk: Int
+        let keysetID: String
+        let active: Bool
+        let tieBreak: UInt64
+    }
+
+    private static func eligibleProofs<P: ProofRepresenting>(
+        _ proofs: [P], mint: some MintRepresenting, unit: String, seed: Data
+    ) throws -> [EligibleProof] {
+        var result: [EligibleProof] = []
+        result.reserveCapacity(proofs.count)
+        for (i, p) in proofs.enumerated() {
+            guard p.amount > 0 else { continue }
+            // v1: only unlocked proofs are spendable inputs (matches send/swap,
+            // which reject inputs carrying a spending condition).
+            if SpendingCondition.deserialize(from: p.secret) != nil { continue }
+            guard let keyset = resolveKeyset(forID: p.keysetID, in: mint) else {
+                throw ProofSelectionError.missingKeysetInformation(keysetID: p.keysetID)
+            }
+            guard keyset.unit == unit else { continue }
+            result.append(EligibleProof(index: i,
+                                        amount: p.amount,
+                                        ppk: keyset.inputFeePPK,
+                                        keysetID: keyset.keysetID,
+                                        active: keyset.active,
+                                        tieBreak: tieBreakValue(seed: seed,
+                                                                keysetID: p.keysetID,
+                                                                C: p.C)))
+        }
+        return result
+    }
+
+    /// Resolves a proof's keyset, handling legacy (12-char), v0 (`00…`) and v1
+    /// (`01…`, possibly shortened) keyset IDs — mirrors `units(for:of:)`.
+    private static func resolveKeyset(forID id: String, in mint: some MintRepresenting) -> Keyset? {
+        if let exact = mint.keysets.first(where: { $0.keysetID == id }) { return exact }
+        if id.hasPrefix("01") {
+            let matches = mint.keysets.filter { $0.keysetID.hasPrefix(id) }
+            if matches.count == 1 { return matches.first }
+        }
+        return nil
+    }
+
+    // MARK: - Binary bundling
+
+    private struct GroupKey: Hashable {
+        let amount: Int
+        let ppk: Int
+        let keysetID: String
+    }
+
+    /// A DP item: a single proof or a binary bundle of interchangeable proofs.
+    private struct SelectionItem {
+        let indices: [Int]    // original proof indices represented by this item
+        let amount: Int
+        let ppk: Int
+        let proofCount: Int
+        let keysetScore: Int
+        let tieBreak: UInt64
+    }
+
+    /// Groups interchangeable proofs `(amount, ppk, keyset)` and binary-splits
+    /// each group's count into bundles `1, 2, 4, …, remainder`, so the DP can
+    /// form any count `0…k` while collapsing item count. `dropFeeDominated`
+    /// removes proofs that can never improve net value in a fee-aware
+    /// transaction (`amount ≤ ⌊ppk/1000⌋`); it must stay `false` for fee-free
+    /// direct sends.
+    private static func bundle(_ eligible: [EligibleProof],
+                               scoreForActive: (Bool) -> Int,
+                               dropFeeDominated: Bool) -> [SelectionItem] {
+        var groups: [GroupKey: [EligibleProof]] = [:]
+        for e in eligible {
+            if dropFeeDominated && e.amount <= e.ppk / 1000 { continue }
+            groups[GroupKey(amount: e.amount, ppk: e.ppk, keysetID: e.keysetID), default: []].append(e)
+        }
+
+        var items: [SelectionItem] = []
+        for (key, membersUnsorted) in groups {
+            // Deterministic member assignment to bundles.
+            let members = membersUnsorted.sorted { $0.tieBreak < $1.tieBreak }
+            let score = scoreForActive(members[0].active)
+            var start = 0
+            for size in binarySplit(members.count) {
+                let slice = members[start ..< start + size]
+                start += size
+                items.append(SelectionItem(indices: slice.map { $0.index },
+                                           amount: key.amount * size,
+                                           ppk: key.ppk * size,
+                                           proofCount: size,
+                                           keysetScore: score * size,
+                                           tieBreak: slice.reduce(UInt64(0)) { $0 ^ $1.tieBreak }))
+            }
+        }
+
+        // Deterministic, iteration-order-independent processing order.
+        items.sort { ($0.amount, $0.ppk, $0.proofCount, $0.tieBreak)
+                   < ($1.amount, $1.ppk, $1.proofCount, $1.tieBreak) }
+        return items
+    }
+
+    /// Splits `count` into a minimal binary cover: `1, 2, 4, …` then the
+    /// remainder (e.g. `13 → [1, 2, 4, 6]`).
+    private static func binarySplit(_ count: Int) -> [Int] {
+        var sizes: [Int] = []
+        var remaining = count
+        var block = 1
+        while remaining > 0 {
+            let take = min(block, remaining)
+            sizes.append(take)
+            remaining -= take
+            block *= 2
+        }
+        return sizes
+    }
+
+    private static func directScorer(_ policy: ProofSelectionPolicy) -> (Bool) -> Int {
+        policy.avoidInactiveKeysetsForDirectSend ? { $0 ? 0 : 1 } : { _ in 0 }
+    }
+
+    private static func mintScorer(_ policy: ProofSelectionPolicy) -> (Bool) -> Int {
+        policy.preferInactiveKeysetsForMintTransactions ? { $0 ? 1 : 0 } : { _ in 0 }
+    }
+
+    // MARK: - DP state
+
+    private struct SelectionState {
+        let amount: Int
+        let ppk: Int
+        let proofCount: Int
+        let keysetScore: Int
+        let tieBreak: UInt64
+        let chosen: [Int]     // indices into the items array (backpointer)
+
+        static let zero = SelectionState(amount: 0, ppk: 0, proofCount: 0,
+                                         keysetScore: 0, tieBreak: 0, chosen: [])
+
+        var fee: Int { ppk <= 0 ? 0 : (ppk + 999) / 1000 }
+        var net: Int { amount - fee }
+
+        func adding(_ item: SelectionItem, itemIndex: Int) -> SelectionState {
+            SelectionState(amount: amount + item.amount,
+                           ppk: ppk + item.ppk,
+                           proofCount: proofCount + item.proofCount,
+                           keysetScore: keysetScore + item.keysetScore,
+                           tieBreak: tieBreak ^ item.tieBreak,
+                           chosen: chosen + [itemIndex])
+        }
+    }
+
+    // MARK: - Stage 1: exact direct subset
+
+    /// Exact subset-sum DP keyed by amount `≤ target`. `dp[a]` keeps the best
+    /// state reaching exactly `a` under the direct comparator. Returns the best
+    /// state reaching exactly `target`, or `nil` if none exists.
+    private static func exactDirectSubset(_ items: [SelectionItem], target: Int) -> SelectionState? {
+        var dp: [Int: SelectionState] = [0: .zero]
+        for (i, item) in items.enumerated() {
+            // Transition only from states that predate this item (0/1 knapsack).
+            let snapshot = dp
+            for amount in snapshot.keys.sorted() {
+                let next = amount + item.amount
+                if next > target { continue }
+                let candidate = snapshot[amount]!.adding(item, itemIndex: i)
+                if let existing = dp[next] {
+                    if directBetter(candidate, than: existing) { dp[next] = candidate }
+                } else {
+                    dp[next] = candidate
+                }
+            }
+        }
+        return dp[target]
+    }
+
+    /// Direct-send comparator: fewest proofs, then lowest total ppk (the
+    /// recipient may later spend the token), then keyset hygiene, then a stable
+    /// tie-break.
+    private static func directBetter(_ a: SelectionState, than b: SelectionState) -> Bool {
+        if a.proofCount != b.proofCount { return a.proofCount < b.proofCount }
+        if a.ppk != b.ppk { return a.ppk < b.ppk }
+        if a.keysetScore != b.keysetScore { return a.keysetScore < b.keysetScore }
+        if a.tieBreak != b.tieBreak { return a.tieBreak < b.tieBreak }
+        return lexLess(a.chosen.sorted(), b.chosen.sorted())
+    }
+
+    // MARK: - Stage 2: fee-aware bounded knapsack
+
+    /// Fee-aware Pareto DP. Finds the selection minimising the mint-transaction
+    /// comparator subject to `net ≥ target`.
+    private static func feeAwareSubset(_ items: [SelectionItem],
+                                       target: Int,
+                                       policy: ProofSelectionPolicy,
+                                       eligibleRawAmount: Int,
+                                       purpose: ProofSelectionPurpose) throws
+    -> (state: SelectionState, optimality: ProofSelectionOptimality) {
+
+        // The all-items selection is the maximum achievable net; if it can't
+        // reach the target nothing can.
+        let allState = items.enumerated().reduce(SelectionState.zero) {
+            $0.adding($1.element, itemIndex: $1.offset)
+        }
+        guard allState.net >= target else {
+            throw ProofSelectionError.insufficientFunds(eligibleRawAmount: eligibleRawAmount,
+                                                         requiredTarget: target,
+                                                         purpose: purpose)
+        }
+
+        // Seed `best` (hence the fee-pruning bound) with cheap feasible
+        // heuristics, falling back to the guaranteed-feasible all-items state.
+        var best = allState
+        for seed in heuristicSeeds(items, target: target) {
+            if mintBetter(seed, than: best, target: target) { best = seed }
+        }
+
+        // states[amount] = Pareto-minimal open (net < target) states at `amount`.
+        var states: [Int: [SelectionState]] = [0: [.zero]]
+        var stateCount = 1
+
+        for (i, item) in items.enumerated() {
+            let snapshot = states
+            for amount in snapshot.keys.sorted() {
+                for state in snapshot[amount]! {
+                    let candidate = state.adding(item, itemIndex: i)
+                    // Adding proofs never lowers ppk, hence never lowers fee:
+                    // a candidate already above the best fee can never win.
+                    if candidate.fee > best.fee { continue }
+                    if candidate.net >= target {
+                        // Feasible: evaluate, but do not extend — extension only
+                        // raises amount/ppk/count, never lowering fee or change.
+                        if mintBetter(candidate, than: best, target: target) { best = candidate }
+                    } else {
+                        insertPareto(candidate, into: &states[candidate.amount, default: []],
+                                     stateCount: &stateCount)
+                    }
+                }
+            }
+            if let maxStates = policy.maxStates, stateCount > maxStates {
+                if policy.bestEffortWhenStateLimitHit {
+                    return (best, .bestEffortStateLimitHit)
+                } else {
+                    throw ProofSelectionError.stateLimitExceeded
+                }
+            }
+        }
+        return (best, .provedOptimal)
+    }
+
+    /// Deterministic greedy feasible candidates to tighten the fee bound before
+    /// the exhaustive DP. Correctness does not depend on these.
+    private static func heuristicSeeds(_ items: [SelectionItem], target: Int) -> [SelectionState] {
+        func greedy(_ order: [Int]) -> SelectionState? {
+            var s = SelectionState.zero
+            for i in order {
+                if s.net >= target { break }
+                s = s.adding(items[i], itemIndex: i)
+            }
+            return s.net >= target ? s : nil
+        }
+        let byAmountDesc = items.indices.sorted { items[$0].amount > items[$1].amount }
+        let byPPKAsc     = items.indices.sorted { (items[$0].ppk, -items[$0].amount)
+                                                < (items[$1].ppk, -items[$1].amount) }
+        let byAmountAsc  = items.indices.sorted { items[$0].amount < items[$1].amount }
+        return [byAmountDesc, byPPKAsc, byAmountAsc].compactMap(greedy)
+    }
+
+    /// Inserts `candidate` into a same-amount Pareto bucket, dropping it if
+    /// dominated and evicting any states it dominates. Dominance uses
+    /// `(ppk, proofCount, keysetScore)` — all additive under future identical
+    /// extensions at equal amount, so a dominated state can never yield a
+    /// better outcome. The random `tieBreak` is deliberately excluded (it would
+    /// neuter pruning); determinism instead comes from deterministic processing
+    /// order plus the final comparator.
+    private static func insertPareto(_ candidate: SelectionState,
+                                     into bucket: inout [SelectionState],
+                                     stateCount: inout Int) {
+        for existing in bucket where weaklyDominates(existing, candidate) { return }
+        let before = bucket.count
+        bucket.removeAll { weaklyDominates(candidate, $0) }
+        stateCount -= (before - bucket.count)
+        bucket.append(candidate)
+        stateCount += 1
+    }
+
+    /// `a` weakly dominates `b` at equal amount (assumed): no worse on any
+    /// future-preserved field. Equal states dominate each other, which dedups.
+    private static func weaklyDominates(_ a: SelectionState, _ b: SelectionState) -> Bool {
+        a.ppk <= b.ppk && a.proofCount <= b.proofCount && a.keysetScore <= b.keysetScore
+    }
+
+    /// Mint-transaction comparator: lowest fee, then change, then proof count,
+    /// then raw amount, then keyset hygiene, then a stable tie-break.
+    private static func mintBetter(_ a: SelectionState, than b: SelectionState, target: Int) -> Bool {
+        let af = a.fee, bf = b.fee
+        if af != bf { return af < bf }
+        let ac = a.net - target, bc = b.net - target
+        if ac != bc { return ac < bc }
+        if a.proofCount != b.proofCount { return a.proofCount < b.proofCount }
+        if a.amount != b.amount { return a.amount < b.amount }
+        if a.keysetScore != b.keysetScore { return a.keysetScore < b.keysetScore }
+        if a.tieBreak != b.tieBreak { return a.tieBreak < b.tieBreak }
+        return lexLess(a.chosen.sorted(), b.chosen.sorted())
+    }
+
+    // MARK: - Result assembly
+
+    private static func directResult<P: ProofRepresenting>(
+        _ state: SelectionState, items: [SelectionItem], proofs: [P], target: Int
+    ) -> ProofSelectionResult<P> {
+        let proofIndices = state.chosen.flatMap { items[$0].indices }.sorted()
+        let selected = proofIndices.map { proofs[$0] }
+        return ProofSelectionResult(kind: .directToken,
+                                    selected: selected,
+                                    inputFee: 0,
+                                    netAmount: target,
+                                    changeAmount: 0,
+                                    sendOutputAmounts: [],
+                                    changeOutputAmounts: [],
+                                    blankOutputAmounts: [],
+                                    keysetIDsSpent: Set(selected.map { $0.keysetID }),
+                                    optimality: .provedOptimal)
+    }
+
+    private static func mintResult<P: ProofRepresenting>(
+        _ state: SelectionState, optimality: ProofSelectionOptimality,
+        items: [SelectionItem], proofs: [P], target: Int, purpose: ProofSelectionPurpose
+    ) -> ProofSelectionResult<P> {
+        let proofIndices = state.chosen.flatMap { items[$0].indices }.sorted()
+        let selected = proofIndices.map { proofs[$0] }
+        let fee = state.fee
+        let net = state.net
+        let change = net - target
+        return ProofSelectionResult(kind: .mintTransaction,
+                                    selected: selected,
+                                    inputFee: fee,
+                                    netAmount: net,
+                                    changeAmount: change,
+                                    sendOutputAmounts: splitIntoBase2Numbers(target),
+                                    changeOutputAmounts: change > 0 ? splitIntoBase2Numbers(change) : [],
+                                    blankOutputAmounts: [],
+                                    keysetIDsSpent: Set(selected.map { $0.keysetID }),
+                                    optimality: optimality)
+    }
+
+    // MARK: - Helpers
+
+    /// Stable per-proof tie-break: `SHA256(seed ‖ keysetID ‖ C)`, first 8 bytes.
+    private static func tieBreakValue(seed: Data, keysetID: String, C: String) -> UInt64 {
+        var hasher = SHA256()
+        hasher.update(data: seed)
+        hasher.update(data: Data(keysetID.utf8))
+        hasher.update(data: Data(C.utf8))
+        var value: UInt64 = 0
+        for byte in hasher.finalize().prefix(8) { value = (value << 8) | UInt64(byte) }
+        return value
+    }
+
+    /// Lexicographic `<` for equal-purpose index lists (ultimate tie-break to
+    /// guarantee a fully deterministic winner regardless of dictionary order).
+    private static func lexLess(_ a: [Int], _ b: [Int]) -> Bool {
+        for (x, y) in zip(a, b) where x != y { return x < y }
+        return a.count < b.count
+    }
+}

--- a/Tests/cashu-swiftTests/ProofSelectionTests.swift
+++ b/Tests/cashu-swiftTests/ProofSelectionTests.swift
@@ -1,0 +1,444 @@
+//
+//  ProofSelectionTests.swift
+//  CashuSwiftTests
+//
+//  Pure unit tests for the fee-aware proof selector — no network. Covers the
+//  documented unit cases, determinism, the generic "select in place" boundary,
+//  binary-bundling round-trips, and brute-force property tests that compare the
+//  dynamic program against exhaustive subset enumeration for small wallets.
+//
+
+import XCTest
+@testable import CashuSwift
+
+// MARK: - Test fixtures
+
+/// Builds a `Keyset` with the given fee rate / activity by decoding minimal JSON
+/// (the model has a custom `Decodable` init and no memberwise initializer).
+private func ks(_ id: String, ppk: Int, active: Bool = true, unit: String = "sat") -> CashuSwift.Keyset {
+    let json = "{\"id\":\"\(id)\",\"unit\":\"\(unit)\",\"active\":\(active),\"input_fee_ppk\":\(ppk)}"
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+private func mint(_ keysets: [CashuSwift.Keyset]) -> CashuSwift.Mint {
+    CashuSwift.Mint(url: URL(string: "https://test.mint")!, keysets: keysets)
+}
+
+/// A valid serialized P2PK spending condition — makes a proof "locked".
+private let lockedSecret = "[\"P2PK\",{\"nonce\":\"abc123\",\"data\":\"02deadbeef\",\"tags\":null}]"
+
+private func proof(_ amount: Int, _ keysetID: String, id: Int, locked: Bool = false) -> CashuSwift.Proof {
+    CashuSwift.Proof(keysetID: keysetID,
+                     amount: amount,
+                     secret: locked ? lockedSecret : "secret-\(id)",
+                     C: "C-\(id)-\(keysetID)",
+                     dleq: nil)
+}
+
+/// A wallet-side proof type distinct from `CashuSwift.Proof`, used to prove the
+/// generic "select in place" boundary returns the caller's own type.
+private struct WalletProof: ProofRepresenting {
+    let keysetID: String
+    let C: String
+    let secret: String
+    let amount: Int
+    let dleq: CashuSwift.DLEQ?
+}
+
+// MARK: - Deterministic RNG (SplitMix64) for property tests
+
+private struct SeededRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+// MARK: - Brute-force oracles
+
+private func ceilFee(_ ppk: Int) -> Int { ppk <= 0 ? 0 : (ppk + 999) / 1000 }
+
+/// Optimal `(fee, change, count, raw)` over all subsets with `net >= target`,
+/// minimised lexicographically. `nil` if no subset is feasible.
+private func bruteForceMint(_ proofs: [(amount: Int, ppk: Int)], target: Int)
+-> (fee: Int, change: Int, count: Int, raw: Int)? {
+    var best: (fee: Int, change: Int, count: Int, raw: Int)?
+    for mask in 0 ..< (1 << proofs.count) {
+        var raw = 0, ppk = 0, count = 0
+        for i in proofs.indices where mask & (1 << i) != 0 {
+            raw += proofs[i].amount; ppk += proofs[i].ppk; count += 1
+        }
+        let fee = ceilFee(ppk)
+        let net = raw - fee
+        guard net >= target else { continue }
+        let cand = (fee: fee, change: net - target, count: count, raw: raw)
+        if best == nil
+            || (cand.fee, cand.change, cand.count, cand.raw)
+             < (best!.fee, best!.change, best!.count, best!.raw) {
+            best = cand
+        }
+    }
+    return best
+}
+
+/// Optimal `(count, ppk)` over subsets summing *exactly* to `target`.
+private func bruteForceExact(_ proofs: [(amount: Int, ppk: Int)], target: Int)
+-> (count: Int, ppk: Int)? {
+    var best: (count: Int, ppk: Int)?
+    for mask in 0 ..< (1 << proofs.count) {
+        var raw = 0, ppk = 0, count = 0
+        for i in proofs.indices where mask & (1 << i) != 0 {
+            raw += proofs[i].amount; ppk += proofs[i].ppk; count += 1
+        }
+        guard raw == target else { continue }
+        if best == nil || (count, ppk) < (best!.count, best!.ppk) { best = (count, ppk) }
+    }
+    return best
+}
+
+final class ProofSelectionTests: XCTestCase {
+
+    // MARK: Documented unit cases
+
+    /// #1 — exact direct send pays no fee.
+    func testDirectExactPaysNoFee() throws {
+        let m = mint([ks("A", ppk: 100)])
+        let proofs = [proof(1, "A", id: 1), proof(2, "A", id: 2), proof(4, "A", id: 3)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 3, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .directToken)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.reduce(0) { $0 + $1.amount }, 3)
+        XCTAssertEqual(r.selected.count, 2)
+        XCTAssertEqual(r.changeAmount, 0)
+    }
+
+    /// #2 — direct exact beats the swap path even with high keyset fees.
+    func testDirectExactBeatsHighFeeSwap() throws {
+        let m = mint([ks("A", ppk: 999)])
+        let proofs = [proof(10, "A", id: 1)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 10, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .directToken)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.count, 1)
+    }
+
+    /// #3 — fee-aware: raw amount is not enough once the fee is subtracted.
+    func testFeeAwareRawAmountNotEnough() {
+        let m = mint([ks("A", ppk: 1000)])
+        let proofs = [proof(100, "A", id: 1)]
+        XCTAssertThrowsError(try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                                         unit: "sat", purpose: .swap)) { error in
+            guard case CashuSwift.ProofSelectionError.insufficientFunds(let raw, let target, _) = error else {
+                return XCTFail("Expected insufficientFunds, got \(error)")
+            }
+            XCTAssertEqual(raw, 100)
+            XCTAssertEqual(target, 100)
+        }
+    }
+
+    /// #4 — fee-aware chooses the lower-fee feasible subset.
+    func testFeeAwareChoosesLowerFee() throws {
+        let m = mint([ks("HI", ppk: 1000), ks("LO", ppk: 0)])
+        let proofs = [proof(100, "HI", id: 1), proof(101, "LO", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.selected.first?.amount, 101)
+        XCTAssertEqual(r.netAmount, 101)
+        XCTAssertEqual(r.changeAmount, 1)
+    }
+
+    /// #5 — rounding boundary: ppk 500 + 500 + 0 rounds up to fee 1.
+    func testFeeRoundingBoundary() throws {
+        let m = mint([ks("F", ppk: 500), ks("Z", ppk: 0)])
+        let proofs = [proof(5, "F", id: 1), proof(5, "F", id: 2), proof(1, "Z", id: 3)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 10, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 3)
+        XCTAssertEqual(r.selected.reduce(0) { $0 + $1.amount }, 11)
+        XCTAssertEqual(r.inputFee, 1)
+        XCTAssertEqual(r.netAmount, 10)
+        XCTAssertEqual(r.changeAmount, 0)
+    }
+
+    /// #6 — fees are computed only from the selected proofs' keysets.
+    func testMultipleKeysetFees() throws {
+        let m = mint([ks("A", ppk: 0), ks("B", ppk: 999)])
+        // Two ways to reach net 8: {8@A} fee 0, or {8@B} fee 1. Lower fee wins.
+        let proofs = [proof(8, "A", id: 1), proof(8, "B", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 8, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.first?.keysetID, "A")
+    }
+
+    /// #7 — for mint transactions, inactive keysets win an otherwise-exact tie.
+    func testInactiveKeysetPreferredForMint() throws {
+        let m = mint([ks("ACT", ppk: 0, active: true), ks("INACT", ppk: 0, active: false)])
+        let proofs = [proof(100, "ACT", id: 1), proof(100, "INACT", id: 2)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.preferInactiveKeysetsForMintTransactions = true
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.selected.first?.keysetID, "INACT")
+    }
+
+    /// #8 — for direct sends, active keysets win an otherwise-exact tie.
+    func testActiveKeysetPreferredForDirectSend() throws {
+        let m = mint([ks("ACT", ppk: 0, active: true), ks("INACT", ppk: 0, active: false)])
+        let proofs = [proof(100, "ACT", id: 1), proof(100, "INACT", id: 2)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.avoidInactiveKeysetsForDirectSend = true
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked, policy: policy)
+        XCTAssertEqual(r.kind, .directToken)
+        XCTAssertEqual(r.selected.first?.keysetID, "ACT")
+    }
+
+    /// #9 — locked proofs are filtered out (not spendable inputs in v1).
+    func testLockedProofsFiltered() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(100, "A", id: 1, locked: true), proof(100, "A", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertFalse(r.selected.contains { $0.secret == lockedSecret })
+
+        // Only a locked proof present ⇒ nothing eligible.
+        XCTAssertThrowsError(try CashuSwift.selectProofs([proof(100, "A", id: 3, locked: true)],
+                                                         targetAmount: 50, mint: m,
+                                                         unit: "sat", purpose: .swap)) { error in
+            guard case CashuSwift.ProofSelectionError.noEligibleProofs = error else {
+                return XCTFail("Expected noEligibleProofs, got \(error)")
+            }
+        }
+    }
+
+    /// #10 — state-limit behaviour is explicit: throw vs. best-effort.
+    func testStateLimitThrows() {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(40, "A", id: 1), proof(40, "A", id: 2), proof(40, "A", id: 3)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.maxStates = 1
+        policy.bestEffortWhenStateLimitHit = false
+        XCTAssertThrowsError(try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                                         unit: "sat", purpose: .swap, policy: policy)) { error in
+            guard case CashuSwift.ProofSelectionError.stateLimitExceeded = error else {
+                return XCTFail("Expected stateLimitExceeded, got \(error)")
+            }
+        }
+    }
+
+    func testStateLimitBestEffort() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(40, "A", id: 1), proof(40, "A", id: 2), proof(40, "A", id: 3)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.maxStates = 1
+        policy.bestEffortWhenStateLimitHit = true
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        XCTAssertEqual(r.optimality, .bestEffortStateLimitHit)
+        XCTAssertGreaterThanOrEqual(r.netAmount, 100)
+    }
+
+    // MARK: Keyset resolution & diagnostics
+
+    func testMissingKeysetThrows() {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(100, "UNKNOWN", id: 1)]
+        XCTAssertThrowsError(try CashuSwift.selectProofs(proofs, targetAmount: 50, mint: m,
+                                                         unit: "sat", purpose: .swap)) { error in
+            guard case CashuSwift.ProofSelectionError.missingKeysetInformation(let id) = error else {
+                return XCTFail("Expected missingKeysetInformation, got \(error)")
+            }
+            XCTAssertEqual(id, "UNKNOWN")
+        }
+    }
+
+    func testWrongUnitFilteredNotThrown() throws {
+        let m = mint([ks("SAT", ppk: 0, unit: "sat"), ks("USD", ppk: 0, unit: "usd")])
+        let proofs = [proof(100, "SAT", id: 1), proof(100, "USD", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.selected.first?.keysetID, "SAT")
+    }
+
+    func testShortV1KeysetIDResolves() throws {
+        let full = "01" + String(repeating: "a", count: 62)   // 64 chars
+        let m = mint([ks(full, ppk: 0)])
+        let shortID = String(full.prefix(16))
+        let proofs = [proof(100, shortID, id: 1)]   // proof carries shortened id
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.keysetIDsSpent, [shortID])
+    }
+
+    // MARK: Determinism & the generic boundary
+
+    func testDeterministicForSameRequest() throws {
+        let m = mint([ks("A", ppk: 1), ks("B", ppk: 2, active: false)])
+        let proofs = (0..<12).map { proof([1, 2, 4, 8][$0 % 4], $0 % 2 == 0 ? "A" : "B", id: $0) }
+        let seed = Data([1, 2, 3, 4])
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.randomSeed = seed
+        let a = try CashuSwift.selectProofs(proofs, targetAmount: 13, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        let b = try CashuSwift.selectProofs(proofs, targetAmount: 13, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        XCTAssertEqual(a.selected.map { $0.C }, b.selected.map { $0.C })
+    }
+
+    /// The "select in place" guarantee: a foreign `ProofRepresenting` type goes
+    /// in, the *same* type comes back — no conversion, no downcast.
+    func testSelectInPlaceReturnsCallerType() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let wallet = [
+            WalletProof(keysetID: "A", C: "wc1", secret: "s1", amount: 4, dleq: nil),
+            WalletProof(keysetID: "A", C: "wc2", secret: "s2", amount: 8, dleq: nil),
+            WalletProof(keysetID: "A", C: "wc3", secret: "s3", amount: 16, dleq: nil),
+        ]
+        let result = try CashuSwift.selectProofs(wallet, targetAmount: 12, mint: m,
+                                                 unit: "sat", purpose: .tokenTransferUnlocked)
+        // Compile-time proof of type preservation:
+        let selected: [WalletProof] = result.selected
+        XCTAssertEqual(selected.reduce(0) { $0 + $1.amount }, 12)
+        // Identity preserved: every returned proof is one of the inputs (by C).
+        let inputCs = Set(wallet.map { $0.C })
+        XCTAssertTrue(selected.allSatisfy { inputCs.contains($0.C) })
+    }
+
+    // MARK: Binary bundling round-trip
+
+    func testBundlingExpandsToDistinctInputProofs() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = (0..<13).map { proof(1, "A", id: $0) }   // 13 identical-shape proofs
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 5, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 5)
+        XCTAssertEqual(r.selected.reduce(0) { $0 + $1.amount }, 5)
+        XCTAssertEqual(r.inputFee, 0)
+        // Distinct, real input proofs.
+        let cs = r.selected.map { $0.C }
+        XCTAssertEqual(Set(cs).count, 5)
+        let inputCs = Set(proofs.map { $0.C })
+        XCTAssertTrue(cs.allSatisfy { inputCs.contains($0) })
+    }
+
+    func testDirectNoExactSubsetFallsToMintTransaction() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(2, "A", id: 1), proof(4, "A", id: 2)]   // no subset sums to 3
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 3, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertGreaterThanOrEqual(r.netAmount, 3)
+    }
+
+    func testMeltTargetIncludesFeeReserve() throws {
+        // Caller passes target = quote.amount + feeReserve. Selection guarantees
+        // net >= target, i.e. sum >= amount + feeReserve + inputFee.
+        let m = mint([ks("A", ppk: 100)])
+        let proofs = (0..<8).map { proof(8, "A", id: $0) }   // 64 sat total
+        let amount = 40, feeReserve = 5
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: amount + feeReserve, mint: m,
+                                            unit: "sat", purpose: .melt)
+        XCTAssertGreaterThanOrEqual(r.netAmount, amount + feeReserve)
+        XCTAssertEqual(r.inputFee, ceilFee(r.selected.count * 100))
+    }
+
+    // MARK: Brute-force property tests
+
+    private let keysetPool: [CashuSwift.Keyset] = [
+        ks("K0", ppk: 0, active: true),
+        ks("K1", ppk: 1, active: true),
+        ks("K2", ppk: 100, active: true),
+        ks("K3", ppk: 999, active: false),
+        ks("K4", ppk: 1000, active: true),
+        ks("K5", ppk: 1001, active: false),
+    ]
+    private let amountPool = [1, 2, 3, 4, 5, 7, 8, 16, 32, 64]
+
+    func testBruteForceFeeAware() throws {
+        let m = mint(keysetPool)
+        var rng = SeededRNG(seed: 0xCA54_F00D)
+        for _ in 0..<1500 {
+            let n = Int.random(in: 1...12, using: &rng)
+            var proofs: [CashuSwift.Proof] = []
+            var oracle: [(amount: Int, ppk: Int)] = []
+            for i in 0..<n {
+                let k = keysetPool[Int.random(in: 0..<keysetPool.count, using: &rng)]
+                let amount = amountPool[Int.random(in: 0..<amountPool.count, using: &rng)]
+                proofs.append(proof(amount, k.keysetID, id: i))
+                oracle.append((amount, k.inputFeePPK))
+            }
+            let allNet = oracle.reduce(0) { $0 + $1.amount } - ceilFee(oracle.reduce(0) { $0 + $1.ppk })
+            guard allNet >= 1 else { continue }
+            let target = Int.random(in: 1...(allNet + 3), using: &rng)   // sometimes infeasible
+
+            let expected = bruteForceMint(oracle, target: target)
+            do {
+                let r = try CashuSwift.selectProofs(proofs, targetAmount: target, mint: m,
+                                                    unit: "sat", purpose: .swap)
+                guard let expected else {
+                    return XCTFail("DP succeeded but brute force found no feasible subset (target \(target))")
+                }
+                let raw = r.selected.reduce(0) { $0 + $1.amount }
+                XCTAssertEqual(r.inputFee, expected.fee, "fee mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(r.changeAmount, expected.change, "change mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(r.selected.count, expected.count, "count mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(raw, expected.raw, "raw mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(r.netAmount, raw - r.inputFee)
+                XCTAssertGreaterThanOrEqual(r.netAmount, target)
+                XCTAssertEqual(Set(r.selected.map { $0.C }).count, r.selected.count, "duplicate proofs selected")
+            } catch CashuSwift.ProofSelectionError.insufficientFunds {
+                XCTAssertNil(expected, "DP reported insufficient but brute force found a subset (target \(target), proofs \(oracle))")
+            }
+        }
+    }
+
+    func testBruteForceDirectExact() throws {
+        let m = mint(keysetPool)
+        var rng = SeededRNG(seed: 0x1234_5678)
+        for _ in 0..<1500 {
+            let n = Int.random(in: 1...12, using: &rng)
+            var proofs: [CashuSwift.Proof] = []
+            var oracle: [(amount: Int, ppk: Int)] = []
+            for i in 0..<n {
+                let k = keysetPool[Int.random(in: 0..<keysetPool.count, using: &rng)]
+                let amount = amountPool[Int.random(in: 0..<amountPool.count, using: &rng)]
+                proofs.append(proof(amount, k.keysetID, id: i))
+                oracle.append((amount, k.inputFeePPK))
+            }
+            // Force a target that has at least one exact subset by summing a random subset.
+            let mask = Int.random(in: 1..<(1 << n), using: &rng)
+            var target = 0
+            for i in 0..<n where mask & (1 << i) != 0 { target += oracle[i].amount }
+
+            let expected = bruteForceExact(oracle, target: target)!   // the chosen subset guarantees one
+            let r = try CashuSwift.selectProofs(proofs, targetAmount: target, mint: m,
+                                                unit: "sat", purpose: .tokenTransferUnlocked)
+            XCTAssertEqual(r.kind, .directToken, "exact subset exists but DP didn't pick a direct send (target \(target), proofs \(oracle))")
+            XCTAssertEqual(r.inputFee, 0)
+            let raw = r.selected.reduce(0) { $0 + $1.amount }
+            XCTAssertEqual(raw, target)
+            // Optimal on (count, ppk).
+            let ppk = r.selected.reduce(0) { partial, p in
+                partial + (keysetPool.first { $0.keysetID == p.keysetID }?.inputFeePPK ?? 0)
+            }
+            XCTAssertEqual(r.selected.count, expected.count, "count not minimal (target \(target), proofs \(oracle))")
+            XCTAssertEqual(ppk, expected.ppk, "ppk not minimal among min-count subsets (target \(target), proofs \(oracle))")
+            XCTAssertEqual(Set(r.selected.map { $0.C }).count, r.selected.count)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a single, self-contained **fee-aware proof selector** that chooses which existing proofs a wallet should spend for a given operation, and removes the library's last bit of internal proof selection (dead greedy helper).

## Interface — "select in place"

`CashuSwift.selectProofs(_:targetAmount:mint:unit:purpose:policy:)` is **generic over any `ProofRepresenting`**; the result's `selected` array holds the caller's *own* proof values (a subset of the input), so a dependent wallet never converts to/from `CashuSwift.Proof`.

- The DP runs entirely on integers and original indices, so the concrete proof type is read only at the boundary — no existentials, no downcasts, and no added `Hashable`/`Equatable` requirement on the protocol.
- New outputs from a swap have no pre-existing identity, so the generic boundary is scoped precisely to *input* selection.

## Algorithm

- **Pure & deterministic** — no networking, crypto, or randomness. The caller refreshes keysets, reserves proofs, and performs the swap/melt.
- **Stage 1** — exact, fee-free subset-sum DP for direct unlocked sends.
- **Stage 2** — fee-aware Pareto bounded-knapsack for mint transactions (swap/melt/receive/…), provably optimal under a documented comparator (lowest NUT-02 input fee → change → proof count → raw amount → keyset hygiene → stable tie-break) unless `policy.maxStates` is hit, in which case optimality is reported truthfully.
- NUT-02 input fees are computed only from the selected proofs' keysets and paid only for mint transactions, never for direct sends.
- Binary bundling of interchangeable proofs, fee-dominated-input pruning, heuristic upper bounds, prefix-aware keyset resolution, and explicit errors (insufficient funds with diagnostics, missing keyset info, state-limit, …).

Everything lives in one file (`Sources/cashu-swift/Operations/ProofSelection.swift`), no new namespaces.

## Dead-code removal

`selectProofs(from:amount:)` (an old greedy selector) and `generateRandomNonce()` in `PaymentRequestOperations.swift` had no call sites. With them gone the library performs **zero internal proof selection**: `send`/`swap`/`melt`/`receive` operate on all caller-supplied proofs and only do sum checks. Selection is now solely the caller's job.

## Tests

`Tests/cashu-swiftTests/ProofSelectionTests.swift` — 21 tests, all green:
- The documented unit cases, determinism, the generic boundary (foreign wallet type in → same type out), bundling round-trips, short-`01…`-keyset resolution, missing-keyset/wrong-unit handling, melt-target invariant.
- **Brute-force property tests** comparing the DP against exhaustive subset enumeration over **1,500 random wallets per stage** (optimality, feasibility, no duplicate selection).

No regressions in the existing pure suites (UnitTests, PaymentRequestTests).

## Out of scope (follow-up)

Wiring the selector into `send`/`swap`/`_melt`, generic overloads for the whole pipeline, and proof-reservation hooks (plan milestone 6).