### PR TITLE
Offline-send optimization: denomination-distribution planning

### DIFF
--- a/Sources/cashu-swift/Operations/DistributionPlanning.swift
+++ b/Sources/cashu-swift/Operations/DistributionPlanning.swift
@@ -1,0 +1,308 @@
+//
+//  DistributionPlanning.swift
+//  CashuSwift
+//
+//  Denomination-distribution planning for offline-send optimization.
+//
+//  A Cashu token is just a bundle of proofs, and an *offline* (unlocked) send of
+//  amount `X` is possible iff the wallet already holds a subset of proofs summing
+//  to exactly `X` — making change requires a swap round-trip to the mint. The
+//  lever for making that true as often as possible is the wallet's *denomination
+//  shape*: hold roughly `N` proofs of each power-of-two denomination so that exact
+//  subsets exist for most amounts, repeatedly.
+//
+//  This file is the pure, deterministic math behind that idea. It computes:
+//
+//    * `idealDistribution(balance:…)` — the most offline-friendly partition of a
+//      balance into powers of two under a per-denomination cap `N`.
+//    * `preferredDistribution(forAmount:retained:…)` — the split for `amount` new
+//      proofs that best moves a retained inventory *toward* the ideal (fills
+//      deficits). The caller feeds it into an operation's `preferredDistribution`
+//      hook.
+//    * `denominationGap(for:…)` — how far a proof set is from its ideal, in both
+//      directions (deficits *and* surplus), so a wallet can decide whether a
+//      fee-incurring consolidation swap is worthwhile.
+//
+//  No networking, crypto, or randomness — given the same inputs the output is
+//  identical. Policy (the value of `N`, when to rebalance) belongs to the wallet;
+//  only the math lives here.
+//
+//  Note on direction: a single output split can only *add* coins, so it can fill
+//  deficits but never remove a surplus. Surpluses are drained by spending
+//  over-represented denominations as inputs (an input-selection concern handled in
+//  `ProofSelection`) or by a full-balance consolidation swap. `denominationGap`
+//  measures both directions so the wallet can drive that decision.
+//
+
+import Foundation
+
+extension CashuSwift {
+
+    // MARK: - Policy
+
+    /// The target denomination shape a wallet wants to maintain so that exact
+    /// (offline-sendable) subsets exist for as many amounts as possible.
+    public struct DenominationTarget: Sendable, Equatable {
+        /// Desired number of proofs to hold of each denomination (`N`). Higher ⇒
+        /// more independent offline payments before a rebalance, at the cost of
+        /// more proofs (bigger tokens, higher future per-proof input fees).
+        public var countPerDenomination: Int
+        /// Optional cap on the largest denomination to target. `nil` ⇒ the largest
+        /// power of two the balance can afford (its top bit), so the usable range
+        /// grows with the balance.
+        public var maxDenomination: Int?
+
+        public init(countPerDenomination: Int = 3, maxDenomination: Int? = nil) {
+            self.countPerDenomination = max(0, countPerDenomination)
+            self.maxDenomination = maxDenomination
+        }
+
+        public static let `default` = DenominationTarget()
+    }
+
+    // MARK: - Gap
+
+    /// How far a proof set is from its target shape, in both directions.
+    public struct DenominationGap: Sendable, Equatable {
+        /// denomination → how many proofs *short* of the target.
+        public let deficits: [Int: Int]
+        /// denomination → how many proofs *over* the target.
+        public let surplus: [Int: Int]
+        /// Total proofs away from the target: `Σ deficits + Σ surplus` (L1 in coin
+        /// counts). `0` ⇒ exactly at target. A wallet can threshold on this to
+        /// decide whether a consolidation swap is worthwhile.
+        public let distance: Int
+
+        public init(deficits: [Int: Int], surplus: [Int: Int], distance: Int) {
+            self.deficits = deficits
+            self.surplus = surplus
+            self.distance = distance
+        }
+    }
+
+    // MARK: - Public API
+
+    /// The ideal denomination shape for `balance`, as a flat, ascending list of
+    /// amounts that sum exactly to `balance`.
+    ///
+    /// Suitable to pass directly as a `preferredReturnDistribution` when swapping
+    /// the whole balance to normalize its shape (a consolidation swap).
+    ///
+    /// - Parameters:
+    ///   - balance: The total amount to partition (e.g. a swap's total output).
+    ///   - target: The desired per-denomination count and optional max denomination.
+    ///   - keyset: Supplies the supported (power-of-two) denominations.
+    /// - Returns: Amounts summing to `balance`; empty if `balance <= 0`.
+    public static func idealDistribution(balance: Int,
+                                         target: DenominationTarget = .default,
+                                         keyset: Keyset) -> [Int] {
+        guard balance > 0 else { return [] }
+        let basis = denominationBasis(keyset: keyset,
+                                      cap: target.maxDenomination ?? topBitDenomination(balance))
+        guard !basis.isEmpty else { return splitIntoBase2Numbers(balance) }
+        return flatten(idealCounts(balance: balance, target: target, denominations: basis))
+    }
+
+    /// The denomination split for `amount` newly-minted proofs that best moves the
+    /// wallet's `retained` inventory toward `target` (fills the largest deficits
+    /// first). Use this for operations that produce new proofs without selecting
+    /// the wallet's own proofs as inputs — `receive` and `mint`.
+    ///
+    /// For operations that *do* select inputs (`send`/swap/consolidation), prefer
+    /// `selectProofs(…, denominationTarget:)`, which has the full proof set and can
+    /// drain surpluses through input selection as well.
+    ///
+    /// The result is guaranteed to sum to exactly `amount`, so it is safe to pass
+    /// into a `preferredDistribution` parameter without a mismatch.
+    ///
+    /// - Parameters:
+    ///   - amount: The sum to materialize as new outputs.
+    ///   - retained: The proofs that will remain after the operation (the wallet's
+    ///     current valid proofs for this mint/unit; nothing is spent by receive/mint).
+    ///   - target: The desired shape.
+    ///   - keyset: Supplies the supported denominations.
+    public static func preferredDistribution(forAmount amount: Int,
+                                             retained: [some ProofRepresenting],
+                                             target: DenominationTarget = .default,
+                                             keyset: Keyset) -> [Int] {
+        guard amount > 0 else { return [] }
+        let retainedCounts = counts(of: retained)
+        let retainedSum = retainedCounts.reduce(0) { $0 + $1.key * $1.value }
+        // The ideal is computed against the projected post-operation balance, since
+        // the new outputs add to what is retained.
+        let projected = retainedSum + amount
+        let basis = denominationBasis(keyset: keyset,
+                                      cap: target.maxDenomination ?? topBitDenomination(projected))
+        guard !basis.isEmpty else { return splitIntoBase2Numbers(amount) }
+        let ideal = idealCounts(balance: projected, target: target, denominations: basis)
+        return fillDistribution(amount: amount, retained: retainedCounts,
+                                ideal: ideal, denominations: basis)
+    }
+
+    /// Measures how far `proofs` are from `target`, in both directions, so a wallet
+    /// can decide whether to consolidate. The ideal is evaluated against the
+    /// current balance (`Σ proofs.amount`).
+    public static func denominationGap(for proofs: [some ProofRepresenting],
+                                       target: DenominationTarget = .default,
+                                       keyset: Keyset) -> DenominationGap {
+        let have = counts(of: proofs)
+        let balance = have.reduce(0) { $0 + $1.key * $1.value }
+        guard balance > 0 else { return DenominationGap(deficits: [:], surplus: [:], distance: 0) }
+        let basis = denominationBasis(keyset: keyset,
+                                      cap: target.maxDenomination ?? topBitDenomination(balance))
+        guard !basis.isEmpty else { return DenominationGap(deficits: [:], surplus: [:], distance: 0) }
+        let ideal = idealCounts(balance: balance, target: target, denominations: basis)
+
+        var deficits: [Int: Int] = [:]
+        var surplus: [Int: Int] = [:]
+        var distance = 0
+        for d in Set(have.keys).union(ideal.keys) {
+            let want = ideal[d] ?? 0
+            let has = have[d] ?? 0
+            if want > has {
+                deficits[d] = want - has
+                distance += want - has
+            } else if has > want {
+                surplus[d] = has - want
+                distance += has - want
+            }
+        }
+        return DenominationGap(deficits: deficits, surplus: surplus, distance: distance)
+    }
+
+    // MARK: - Internal math (kept internal: reachable from tests via @testable,
+    //         but not part of the public surface — callers go through the API above)
+
+    /// Buckets proofs by amount: `amount → count`. Ignores non-positive amounts.
+    static func counts<P: ProofRepresenting>(of proofs: [P]) -> [Int: Int] {
+        var result: [Int: Int] = [:]
+        for p in proofs where p.amount > 0 { result[p.amount, default: 0] += 1 }
+        return result
+    }
+
+    /// The power-of-two denominations a keyset offers, ascending. Parses the integer
+    /// amount keys of `keyset.keys` and keeps only positive powers of two — this
+    /// naturally drops the empty-string placeholder used before keys are loaded, as
+    /// well as any non-power-of-two entries.
+    static func supportedDenominations(of keyset: Keyset) -> [Int] {
+        keyset.keys.keys
+            .compactMap { Int($0) }
+            .filter { $0 > 0 && ($0 & ($0 - 1)) == 0 }
+            .sorted()
+    }
+
+    /// The effective denomination basis to plan over: the keyset's supported
+    /// denominations no greater than `cap`, or — if the keyset enumerates none
+    /// (keys not yet loaded) — synthesized powers of two up to `cap`. Always
+    /// includes `1` in the fallback, guaranteeing exact decomposition.
+    static func denominationBasis(keyset: Keyset, cap: Int) -> [Int] {
+        let supported = supportedDenominations(of: keyset).filter { $0 <= cap }
+        return supported.isEmpty ? powersOfTwo(upTo: cap) : supported
+    }
+
+    /// Powers of two `1, 2, 4, …` up to and including `cap` (empty if `cap < 1`).
+    static func powersOfTwo(upTo cap: Int) -> [Int] {
+        guard cap >= 1 else { return [] }
+        var result: [Int] = []
+        var d = 1
+        while d <= cap {
+            result.append(d)
+            d <<= 1
+        }
+        return result
+    }
+
+    /// The largest power of two `≤ n` (its top set bit); `0` for `n <= 0`.
+    static func topBitDenomination(_ n: Int) -> Int {
+        guard n > 0 else { return 0 }
+        return 1 << (Int.bitWidth - 1 - n.leadingZeroBitCount)
+    }
+
+    /// The ideal `denomination → count` shape for `balance`.
+    ///
+    /// Two passes over the (ascending) basis:
+    ///   1. **Soft fill, small-first:** give each denomination up to `N` coins,
+    ///      smallest first — front-loading redundancy on the small/medium
+    ///      denominations that everyday offline payments deplete.
+    ///   2. **Remainder absorption, large-first:** whatever budget is left (because
+    ///      `N` of each was already met, or larger denominations were capped) is
+    ///      soaked up by the largest denominations, exceeding `N` where needed.
+    ///
+    /// Sums to exactly `balance` provided the basis includes `1` (always true for a
+    /// real keyset and for the synthesized fallback).
+    static func idealCounts(balance: Int,
+                            target: DenominationTarget,
+                            denominations: [Int]) -> [Int: Int] {
+        var result: [Int: Int] = [:]
+        var remaining = balance
+
+        let n = target.countPerDenomination
+        if n > 0 {
+            for d in denominations {           // ascending
+                guard remaining >= d else { continue }
+                let add = min(n, remaining / d)
+                if add > 0 {
+                    result[d, default: 0] += add
+                    remaining -= add * d
+                }
+            }
+        }
+
+        for d in denominations.reversed() {    // descending
+            guard remaining >= d else { continue }
+            let add = remaining / d
+            result[d, default: 0] += add
+            remaining -= add * d
+        }
+        return result
+    }
+
+    /// The split for `amount` new outputs that best fills the deficit between
+    /// `retained` and `ideal`.
+    ///
+    ///   1. **Fill deficits, small-first:** create the under-represented
+    ///      denominations the wallet is short of, smallest first.
+    ///   2. **Absorb the remainder, large-first:** any budget beyond the total
+    ///      deficit (which is small — the ideal is sized for the projected balance)
+    ///      is emitted as the fewest possible coins, minimizing how much it adds to
+    ///      any already-satisfied denomination.
+    ///
+    /// Sums to exactly `amount` (basis includes `1`). Fills deficits only — it
+    /// cannot remove a surplus; that is the job of input selection / consolidation.
+    static func fillDistribution(amount: Int,
+                                 retained: [Int: Int],
+                                 ideal: [Int: Int],
+                                 denominations: [Int]) -> [Int] {
+        var out: [Int: Int] = [:]
+        var remaining = amount
+
+        for d in denominations {               // ascending: satisfy explicit deficits
+            guard remaining >= d else { continue }
+            let deficit = max(0, (ideal[d] ?? 0) - (retained[d] ?? 0))
+            guard deficit > 0 else { continue }
+            let add = min(deficit, remaining / d)
+            if add > 0 {
+                out[d, default: 0] += add
+                remaining -= add * d
+            }
+        }
+
+        for d in denominations.reversed() {    // descending: absorb remainder in fewest coins
+            guard remaining >= d else { continue }
+            let add = remaining / d
+            out[d, default: 0] += add
+            remaining -= add * d
+        }
+        return flatten(out)
+    }
+
+    /// Flattens a `denomination → count` map into an ascending list of amounts.
+    static func flatten(_ counts: [Int: Int]) -> [Int] {
+        var result: [Int] = []
+        for d in counts.keys.sorted() {
+            let c = counts[d] ?? 0
+            if c > 0 { result.append(contentsOf: repeatElement(d, count: c)) }
+        }
+        return result
+    }
+}

--- a/Sources/cashu-swift/Operations/PaymentRequestOperations.swift
+++ b/Sources/cashu-swift/Operations/PaymentRequestOperations.swift
@@ -121,33 +121,4 @@ extension CashuSwift {
         let bytes = (0..<4).map { _ in UInt8.random(in: 0...255) }
         return bytes.map { String(format: "%02x", $0) }.joined()
     }
-    
-    /// Generates a random nonce for spending conditions.
-    private static func generateRandomNonce() -> String {
-        let bytes = (0..<32).map { _ in UInt8.random(in: 0...255) }
-        return bytes.map { String(format: "%02x", $0) }.joined()
-    }
-    
-    /// Selects proofs to cover a specific amount.
-    private static func selectProofs(from proofs: [Proof], amount: Int) throws -> [Proof] {
-        var selected: [Proof] = []
-        var total = 0
-        
-        // Sort proofs by amount (smallest first for better selection)
-        let sortedProofs = proofs.sorted { $0.amount < $1.amount }
-        
-        for proof in sortedProofs {
-            if total >= amount {
-                break
-            }
-            selected.append(proof)
-            total += proof.amount
-        }
-        
-        guard total >= amount else {
-            throw CashuError.insufficientInputs("Cannot select enough proofs to cover amount \(amount)")
-        }
-        
-        return selected
-    }
 }

--- a/Sources/cashu-swift/Operations/ProofSelection.swift
+++ b/Sources/cashu-swift/Operations/ProofSelection.swift
@@ -1,0 +1,582 @@
+//
+//  ProofSelection.swift
+//  CashuSwift
+//
+//  Fee-aware ecash proof selection — a single, self-contained selector that
+//  chooses which existing proofs a wallet should spend for a given operation.
+//
+//  Design goals:
+//
+//    * Generic & identity-preserving ("select in place"). `selectProofs` is
+//      generic over any `ProofRepresenting`; the result's `selected` array
+//      holds the *caller's own* proof values (a subset of the input), never
+//      copies. A dependent wallet never converts to/from `CashuSwift.Proof`.
+//      The dynamic program runs entirely on integers and original indices, so
+//      the concrete proof type is read only at the boundary — no existentials,
+//      no downcasts, and no added `Hashable`/`Equatable` requirement on
+//      `ProofRepresenting`.
+//
+//    * Pure & deterministic. No networking, crypto, or randomness. The caller
+//      refreshes keysets, reserves proofs, and performs the swap/melt. Given
+//      the same request + policy seed the result is identical.
+//
+//    * Exact. Direct (fee-free) sends use exact subset-sum DP; mint
+//      transactions use a fee-aware Pareto bounded-knapsack that is provably
+//      optimal under the documented comparator unless `policy.maxStates` is hit
+//      (in which case optimality is reported truthfully).
+//
+//  NUT-02 input fees: fee(S) = ceil( Σ inputFeePPK(S) / 1000 ), paid only when
+//  a mint transaction (swap/melt/receive/…) is required — never for a direct
+//  token send of existing proofs.
+//
+
+import Foundation
+import CryptoKit
+
+extension CashuSwift {
+
+    // MARK: - Public API
+
+    /// Why proofs are being selected. Determines whether a zero-fee *direct*
+    /// send of existing proofs is acceptable, or whether a fee-bearing *mint
+    /// transaction* (swap/melt/…) is required.
+    public enum ProofSelectionPurpose: Sendable, Equatable {
+        case tokenTransferUnlocked
+        case tokenTransferLocked
+        case paymentRequest
+        case swap
+        case melt
+        case receive
+        case maintenanceRotation
+
+        /// Whether an exact, fee-free subset of existing proofs may satisfy the
+        /// request. Only an unlocked direct transfer can be fulfilled without a
+        /// mint transaction; every other purpose mints new outputs and pays the
+        /// NUT-02 input fee.
+        var allowsDirectExact: Bool { self == .tokenTransferUnlocked }
+    }
+
+    /// Tunable selection behaviour. Defaults match the wallet policy from the
+    /// implementation plan: prefer exact direct sends, then minimise actual fee,
+    /// change, proof count, and raw amount, then keyset hygiene, then a stable
+    /// deterministic tie-break.
+    public struct ProofSelectionPolicy: Sendable {
+        /// Try an exact, fee-free direct subset before fee-aware selection
+        /// (only consulted for purposes whose `allowsDirectExact` is true).
+        public var preferDirectExact: Bool
+        /// For mint transactions, break otherwise-equal candidates by spending
+        /// *inactive* keysets first (keyset hygiene). Never overrides
+        /// fee/change/count/amount.
+        public var preferInactiveKeysetsForMintTransactions: Bool
+        /// For direct sends, break otherwise-equal candidates by keeping the
+        /// recipient on *active* keysets. Never overrides proof-count/fee order.
+        public var avoidInactiveKeysetsForDirectSend: Bool
+        /// Guardrail on the fee-aware open-state count. `nil` disables the cap.
+        public var maxStates: Int?
+        /// When the state cap is hit: return the best feasible result found so
+        /// far (`true`) or throw `.stateLimitExceeded` (`false`).
+        public var bestEffortWhenStateLimitHit: Bool
+        /// Stable per-request entropy for deterministic tie-breaking. Never
+        /// serialized into tokens or sent to the mint. Empty ⇒ fixed ordering
+        /// (handy for tests); supply randomness to rotate which equal-shaped
+        /// proofs get spent over time.
+        public var randomSeed: Data
+
+        public init(preferDirectExact: Bool = true,
+                    preferInactiveKeysetsForMintTransactions: Bool = false,
+                    avoidInactiveKeysetsForDirectSend: Bool = false,
+                    maxStates: Int? = 200_000,
+                    bestEffortWhenStateLimitHit: Bool = false,
+                    randomSeed: Data = Data()) {
+            self.preferDirectExact = preferDirectExact
+            self.preferInactiveKeysetsForMintTransactions = preferInactiveKeysetsForMintTransactions
+            self.avoidInactiveKeysetsForDirectSend = avoidInactiveKeysetsForDirectSend
+            self.maxStates = maxStates
+            self.bestEffortWhenStateLimitHit = bestEffortWhenStateLimitHit
+            self.randomSeed = randomSeed
+        }
+
+        public static let `default` = ProofSelectionPolicy()
+    }
+
+    /// Whether the result is a direct token send (no mint interaction) or a
+    /// mint transaction (swap/melt) the caller must execute.
+    public enum ProofSelectionKind: Sendable, Equatable { case directToken, mintTransaction }
+
+    /// Whether the selection is mathematically proven optimal under the
+    /// comparator, or a best-effort result returned because the state cap hit.
+    public enum ProofSelectionOptimality: Sendable, Equatable { case provedOptimal, bestEffortStateLimitHit }
+
+    /// Result of a selection.
+    ///
+    /// `selected` are the *caller's own* proof values — a subset of the array
+    /// passed to `selectProofs`, never reconstructed — so a dependent wallet
+    /// can reserve/spend them by identity without any type conversion.
+    public struct ProofSelectionResult<P: ProofRepresenting> {
+        public let kind: ProofSelectionKind
+        /// The chosen proofs, a subset of the caller's input (ascending input order).
+        public let selected: [P]
+        /// NUT-02 input fee for `selected` (0 for a direct token send).
+        public let inputFee: Int
+        /// `Σ selected.amount − inputFee`.
+        public let netAmount: Int
+        /// `netAmount − targetAmount` (0 for a direct token send).
+        public let changeAmount: Int
+        /// Denomination split for the send/payment outputs (empty for direct).
+        public let sendOutputAmounts: [Int]
+        /// Denomination split for the change outputs (empty for direct / no change).
+        public let changeOutputAmounts: [Int]
+        /// NUT-08 blank-output amounts. Always empty here: melt callers size
+        /// blanks via `generateBlankOutputs(quote:proofs:…)` from `selected`,
+        /// reusing the library's vetted overpaid-fee-return logic rather than
+        /// duplicating it (the selector does not know `quote.amount`).
+        public let blankOutputAmounts: [Int]
+        /// Keysets the selected proofs are drawn from.
+        public let keysetIDsSpent: Set<String>
+        public let optimality: ProofSelectionOptimality
+    }
+
+    public enum ProofSelectionError: Error, Sendable {
+        /// No subset of eligible proofs can reach the target. Diagnostics avoid
+        /// leaking secrets.
+        case insufficientFunds(eligibleRawAmount: Int, requiredTarget: Int, purpose: ProofSelectionPurpose)
+        /// Every input was filtered out (wrong unit, locked, zero-amount, …).
+        case noEligibleProofs
+        /// A proof's keyset could not be resolved against the provided mint —
+        /// likely stale keyset data. The caller should refresh keysets and
+        /// retry. Unknown fee info is never silently treated as 0.
+        case missingKeysetInformation(keysetID: String)
+        /// The fee-aware search exceeded `policy.maxStates` and best-effort
+        /// fallback was disabled.
+        case stateLimitExceeded
+        /// `targetAmount` was negative.
+        case invalidTarget
+        case unsupportedPurpose(ProofSelectionPurpose)
+    }
+
+    /// Selects which existing proofs to spend for `purpose`.
+    ///
+    /// Identity-preserving: returns the caller's own `P` values (see
+    /// `ProofSelectionResult.selected`).
+    ///
+    /// - Parameters:
+    ///   - proofs: Candidate proofs. The wallet should pass unreserved proofs
+    ///     for this `mint`/`unit`; reservation/concurrency is the caller's job.
+    ///   - targetAmount: Amount to send/pay. For melt, pass
+    ///     `quote.amount + feeReserve`; the selector's `net ≥ target` invariant
+    ///     reproduces `Σ ≥ amount + feeReserve + inputFee`.
+    ///   - mint: Source of per-keyset fee rates and active/inactive status.
+    ///   - unit: The unit being spent (e.g. `"sat"`).
+    ///   - purpose: Drives direct-vs-mint-transaction behaviour.
+    ///   - policy: Tie-breaking knobs and guardrails.
+    /// - Returns: A `ProofSelectionResult` over the caller's proof type.
+    /// - Throws: `ProofSelectionError` on infeasible / invalid / stale-keyset input.
+    public static func selectProofs<P: ProofRepresenting>(
+        _ proofs: [P],
+        targetAmount: Int,
+        mint: some MintRepresenting,
+        unit: String,
+        purpose: ProofSelectionPurpose,
+        policy: ProofSelectionPolicy = .default
+    ) throws -> ProofSelectionResult<P> {
+
+        guard targetAmount >= 0 else { throw ProofSelectionError.invalidTarget }
+
+        let eligible = try eligibleProofs(proofs, mint: mint, unit: unit, seed: policy.randomSeed)
+        guard !eligible.isEmpty else { throw ProofSelectionError.noEligibleProofs }
+
+        if targetAmount == 0 {
+            return ProofSelectionResult(kind: .directToken, selected: [], inputFee: 0,
+                                        netAmount: 0, changeAmount: 0, sendOutputAmounts: [],
+                                        changeOutputAmounts: [], blankOutputAmounts: [],
+                                        keysetIDsSpent: [], optimality: .provedOptimal)
+        }
+
+        // Stage 1 — exact, fee-free direct subset.
+        if purpose.allowsDirectExact && policy.preferDirectExact {
+            let directItems = bundle(eligible,
+                                     scoreForActive: directScorer(policy),
+                                     dropFeeDominated: false)
+            if let state = exactDirectSubset(directItems, target: targetAmount) {
+                return directResult(state, items: directItems, proofs: proofs, target: targetAmount)
+            }
+        }
+
+        // Stage 2 — fee-aware bounded knapsack (mint transaction).
+        let mintItems = bundle(eligible,
+                               scoreForActive: mintScorer(policy),
+                               dropFeeDominated: true)
+        let eligibleRaw = eligible.reduce(0) { $0 + $1.amount }
+        let outcome = try feeAwareSubset(mintItems, target: targetAmount, policy: policy,
+                                         eligibleRawAmount: eligibleRaw, purpose: purpose)
+        return mintResult(outcome.state, optimality: outcome.optimality,
+                          items: mintItems, proofs: proofs, target: targetAmount, purpose: purpose)
+    }
+
+    // MARK: - Eligibility & keyset resolution
+
+    private struct EligibleProof {
+        let index: Int        // original index into the caller's array
+        let amount: Int
+        let ppk: Int
+        let keysetID: String
+        let active: Bool
+        let tieBreak: UInt64
+    }
+
+    private static func eligibleProofs<P: ProofRepresenting>(
+        _ proofs: [P], mint: some MintRepresenting, unit: String, seed: Data
+    ) throws -> [EligibleProof] {
+        var result: [EligibleProof] = []
+        result.reserveCapacity(proofs.count)
+        for (i, p) in proofs.enumerated() {
+            guard p.amount > 0 else { continue }
+            // v1: only unlocked proofs are spendable inputs (matches send/swap,
+            // which reject inputs carrying a spending condition).
+            if SpendingCondition.deserialize(from: p.secret) != nil { continue }
+            guard let keyset = resolveKeyset(forID: p.keysetID, in: mint) else {
+                throw ProofSelectionError.missingKeysetInformation(keysetID: p.keysetID)
+            }
+            guard keyset.unit == unit else { continue }
+            result.append(EligibleProof(index: i,
+                                        amount: p.amount,
+                                        ppk: keyset.inputFeePPK,
+                                        keysetID: keyset.keysetID,
+                                        active: keyset.active,
+                                        tieBreak: tieBreakValue(seed: seed,
+                                                                keysetID: p.keysetID,
+                                                                C: p.C)))
+        }
+        return result
+    }
+
+    /// Resolves a proof's keyset, handling legacy (12-char), v0 (`00…`) and v1
+    /// (`01…`, possibly shortened) keyset IDs — mirrors `units(for:of:)`.
+    private static func resolveKeyset(forID id: String, in mint: some MintRepresenting) -> Keyset? {
+        if let exact = mint.keysets.first(where: { $0.keysetID == id }) { return exact }
+        if id.hasPrefix("01") {
+            let matches = mint.keysets.filter { $0.keysetID.hasPrefix(id) }
+            if matches.count == 1 { return matches.first }
+        }
+        return nil
+    }
+
+    // MARK: - Binary bundling
+
+    private struct GroupKey: Hashable {
+        let amount: Int
+        let ppk: Int
+        let keysetID: String
+    }
+
+    /// A DP item: a single proof or a binary bundle of interchangeable proofs.
+    private struct SelectionItem {
+        let indices: [Int]    // original proof indices represented by this item
+        let amount: Int
+        let ppk: Int
+        let proofCount: Int
+        let keysetScore: Int
+        let tieBreak: UInt64
+    }
+
+    /// Groups interchangeable proofs `(amount, ppk, keyset)` and binary-splits
+    /// each group's count into bundles `1, 2, 4, …, remainder`, so the DP can
+    /// form any count `0…k` while collapsing item count. `dropFeeDominated`
+    /// removes proofs that can never improve net value in a fee-aware
+    /// transaction (`amount ≤ ⌊ppk/1000⌋`); it must stay `false` for fee-free
+    /// direct sends.
+    private static func bundle(_ eligible: [EligibleProof],
+                               scoreForActive: (Bool) -> Int,
+                               dropFeeDominated: Bool) -> [SelectionItem] {
+        var groups: [GroupKey: [EligibleProof]] = [:]
+        for e in eligible {
+            if dropFeeDominated && e.amount <= e.ppk / 1000 { continue }
+            groups[GroupKey(amount: e.amount, ppk: e.ppk, keysetID: e.keysetID), default: []].append(e)
+        }
+
+        var items: [SelectionItem] = []
+        for (key, membersUnsorted) in groups {
+            // Deterministic member assignment to bundles.
+            let members = membersUnsorted.sorted { $0.tieBreak < $1.tieBreak }
+            let score = scoreForActive(members[0].active)
+            var start = 0
+            for size in binarySplit(members.count) {
+                let slice = members[start ..< start + size]
+                start += size
+                items.append(SelectionItem(indices: slice.map { $0.index },
+                                           amount: key.amount * size,
+                                           ppk: key.ppk * size,
+                                           proofCount: size,
+                                           keysetScore: score * size,
+                                           tieBreak: slice.reduce(UInt64(0)) { $0 ^ $1.tieBreak }))
+            }
+        }
+
+        // Deterministic, iteration-order-independent processing order.
+        items.sort { ($0.amount, $0.ppk, $0.proofCount, $0.tieBreak)
+                   < ($1.amount, $1.ppk, $1.proofCount, $1.tieBreak) }
+        return items
+    }
+
+    /// Splits `count` into a minimal binary cover: `1, 2, 4, …` then the
+    /// remainder (e.g. `13 → [1, 2, 4, 6]`).
+    private static func binarySplit(_ count: Int) -> [Int] {
+        var sizes: [Int] = []
+        var remaining = count
+        var block = 1
+        while remaining > 0 {
+            let take = min(block, remaining)
+            sizes.append(take)
+            remaining -= take
+            block *= 2
+        }
+        return sizes
+    }
+
+    private static func directScorer(_ policy: ProofSelectionPolicy) -> (Bool) -> Int {
+        policy.avoidInactiveKeysetsForDirectSend ? { $0 ? 0 : 1 } : { _ in 0 }
+    }
+
+    private static func mintScorer(_ policy: ProofSelectionPolicy) -> (Bool) -> Int {
+        policy.preferInactiveKeysetsForMintTransactions ? { $0 ? 1 : 0 } : { _ in 0 }
+    }
+
+    // MARK: - DP state
+
+    private struct SelectionState {
+        let amount: Int
+        let ppk: Int
+        let proofCount: Int
+        let keysetScore: Int
+        let tieBreak: UInt64
+        let chosen: [Int]     // indices into the items array (backpointer)
+
+        static let zero = SelectionState(amount: 0, ppk: 0, proofCount: 0,
+                                         keysetScore: 0, tieBreak: 0, chosen: [])
+
+        var fee: Int { ppk <= 0 ? 0 : (ppk + 999) / 1000 }
+        var net: Int { amount - fee }
+
+        func adding(_ item: SelectionItem, itemIndex: Int) -> SelectionState {
+            SelectionState(amount: amount + item.amount,
+                           ppk: ppk + item.ppk,
+                           proofCount: proofCount + item.proofCount,
+                           keysetScore: keysetScore + item.keysetScore,
+                           tieBreak: tieBreak ^ item.tieBreak,
+                           chosen: chosen + [itemIndex])
+        }
+    }
+
+    // MARK: - Stage 1: exact direct subset
+
+    /// Exact subset-sum DP keyed by amount `≤ target`. `dp[a]` keeps the best
+    /// state reaching exactly `a` under the direct comparator. Returns the best
+    /// state reaching exactly `target`, or `nil` if none exists.
+    private static func exactDirectSubset(_ items: [SelectionItem], target: Int) -> SelectionState? {
+        var dp: [Int: SelectionState] = [0: .zero]
+        for (i, item) in items.enumerated() {
+            // Transition only from states that predate this item (0/1 knapsack).
+            let snapshot = dp
+            for amount in snapshot.keys.sorted() {
+                let next = amount + item.amount
+                if next > target { continue }
+                let candidate = snapshot[amount]!.adding(item, itemIndex: i)
+                if let existing = dp[next] {
+                    if directBetter(candidate, than: existing) { dp[next] = candidate }
+                } else {
+                    dp[next] = candidate
+                }
+            }
+        }
+        return dp[target]
+    }
+
+    /// Direct-send comparator: fewest proofs, then lowest total ppk (the
+    /// recipient may later spend the token), then keyset hygiene, then a stable
+    /// tie-break.
+    private static func directBetter(_ a: SelectionState, than b: SelectionState) -> Bool {
+        if a.proofCount != b.proofCount { return a.proofCount < b.proofCount }
+        if a.ppk != b.ppk { return a.ppk < b.ppk }
+        if a.keysetScore != b.keysetScore { return a.keysetScore < b.keysetScore }
+        if a.tieBreak != b.tieBreak { return a.tieBreak < b.tieBreak }
+        return lexLess(a.chosen.sorted(), b.chosen.sorted())
+    }
+
+    // MARK: - Stage 2: fee-aware bounded knapsack
+
+    /// Fee-aware Pareto DP. Finds the selection minimising the mint-transaction
+    /// comparator subject to `net ≥ target`.
+    private static func feeAwareSubset(_ items: [SelectionItem],
+                                       target: Int,
+                                       policy: ProofSelectionPolicy,
+                                       eligibleRawAmount: Int,
+                                       purpose: ProofSelectionPurpose) throws
+    -> (state: SelectionState, optimality: ProofSelectionOptimality) {
+
+        // The all-items selection is the maximum achievable net; if it can't
+        // reach the target nothing can.
+        let allState = items.enumerated().reduce(SelectionState.zero) {
+            $0.adding($1.element, itemIndex: $1.offset)
+        }
+        guard allState.net >= target else {
+            throw ProofSelectionError.insufficientFunds(eligibleRawAmount: eligibleRawAmount,
+                                                         requiredTarget: target,
+                                                         purpose: purpose)
+        }
+
+        // Seed `best` (hence the fee-pruning bound) with cheap feasible
+        // heuristics, falling back to the guaranteed-feasible all-items state.
+        var best = allState
+        for seed in heuristicSeeds(items, target: target) {
+            if mintBetter(seed, than: best, target: target) { best = seed }
+        }
+
+        // states[amount] = Pareto-minimal open (net < target) states at `amount`.
+        var states: [Int: [SelectionState]] = [0: [.zero]]
+        var stateCount = 1
+
+        for (i, item) in items.enumerated() {
+            let snapshot = states
+            for amount in snapshot.keys.sorted() {
+                for state in snapshot[amount]! {
+                    let candidate = state.adding(item, itemIndex: i)
+                    // Adding proofs never lowers ppk, hence never lowers fee:
+                    // a candidate already above the best fee can never win.
+                    if candidate.fee > best.fee { continue }
+                    if candidate.net >= target {
+                        // Feasible: evaluate, but do not extend — extension only
+                        // raises amount/ppk/count, never lowering fee or change.
+                        if mintBetter(candidate, than: best, target: target) { best = candidate }
+                    } else {
+                        insertPareto(candidate, into: &states[candidate.amount, default: []],
+                                     stateCount: &stateCount)
+                    }
+                }
+            }
+            if let maxStates = policy.maxStates, stateCount > maxStates {
+                if policy.bestEffortWhenStateLimitHit {
+                    return (best, .bestEffortStateLimitHit)
+                } else {
+                    throw ProofSelectionError.stateLimitExceeded
+                }
+            }
+        }
+        return (best, .provedOptimal)
+    }
+
+    /// Deterministic greedy feasible candidates to tighten the fee bound before
+    /// the exhaustive DP. Correctness does not depend on these.
+    private static func heuristicSeeds(_ items: [SelectionItem], target: Int) -> [SelectionState] {
+        func greedy(_ order: [Int]) -> SelectionState? {
+            var s = SelectionState.zero
+            for i in order {
+                if s.net >= target { break }
+                s = s.adding(items[i], itemIndex: i)
+            }
+            return s.net >= target ? s : nil
+        }
+        let byAmountDesc = items.indices.sorted { items[$0].amount > items[$1].amount }
+        let byPPKAsc     = items.indices.sorted { (items[$0].ppk, -items[$0].amount)
+                                                < (items[$1].ppk, -items[$1].amount) }
+        let byAmountAsc  = items.indices.sorted { items[$0].amount < items[$1].amount }
+        return [byAmountDesc, byPPKAsc, byAmountAsc].compactMap(greedy)
+    }
+
+    /// Inserts `candidate` into a same-amount Pareto bucket, dropping it if
+    /// dominated and evicting any states it dominates. Dominance uses
+    /// `(ppk, proofCount, keysetScore)` — all additive under future identical
+    /// extensions at equal amount, so a dominated state can never yield a
+    /// better outcome. The random `tieBreak` is deliberately excluded (it would
+    /// neuter pruning); determinism instead comes from deterministic processing
+    /// order plus the final comparator.
+    private static func insertPareto(_ candidate: SelectionState,
+                                     into bucket: inout [SelectionState],
+                                     stateCount: inout Int) {
+        for existing in bucket where weaklyDominates(existing, candidate) { return }
+        let before = bucket.count
+        bucket.removeAll { weaklyDominates(candidate, $0) }
+        stateCount -= (before - bucket.count)
+        bucket.append(candidate)
+        stateCount += 1
+    }
+
+    /// `a` weakly dominates `b` at equal amount (assumed): no worse on any
+    /// future-preserved field. Equal states dominate each other, which dedups.
+    private static func weaklyDominates(_ a: SelectionState, _ b: SelectionState) -> Bool {
+        a.ppk <= b.ppk && a.proofCount <= b.proofCount && a.keysetScore <= b.keysetScore
+    }
+
+    /// Mint-transaction comparator: lowest fee, then change, then proof count,
+    /// then raw amount, then keyset hygiene, then a stable tie-break.
+    private static func mintBetter(_ a: SelectionState, than b: SelectionState, target: Int) -> Bool {
+        let af = a.fee, bf = b.fee
+        if af != bf { return af < bf }
+        let ac = a.net - target, bc = b.net - target
+        if ac != bc { return ac < bc }
+        if a.proofCount != b.proofCount { return a.proofCount < b.proofCount }
+        if a.amount != b.amount { return a.amount < b.amount }
+        if a.keysetScore != b.keysetScore { return a.keysetScore < b.keysetScore }
+        if a.tieBreak != b.tieBreak { return a.tieBreak < b.tieBreak }
+        return lexLess(a.chosen.sorted(), b.chosen.sorted())
+    }
+
+    // MARK: - Result assembly
+
+    private static func directResult<P: ProofRepresenting>(
+        _ state: SelectionState, items: [SelectionItem], proofs: [P], target: Int
+    ) -> ProofSelectionResult<P> {
+        let proofIndices = state.chosen.flatMap { items[$0].indices }.sorted()
+        let selected = proofIndices.map { proofs[$0] }
+        return ProofSelectionResult(kind: .directToken,
+                                    selected: selected,
+                                    inputFee: 0,
+                                    netAmount: target,
+                                    changeAmount: 0,
+                                    sendOutputAmounts: [],
+                                    changeOutputAmounts: [],
+                                    blankOutputAmounts: [],
+                                    keysetIDsSpent: Set(selected.map { $0.keysetID }),
+                                    optimality: .provedOptimal)
+    }
+
+    private static func mintResult<P: ProofRepresenting>(
+        _ state: SelectionState, optimality: ProofSelectionOptimality,
+        items: [SelectionItem], proofs: [P], target: Int, purpose: ProofSelectionPurpose
+    ) -> ProofSelectionResult<P> {
+        let proofIndices = state.chosen.flatMap { items[$0].indices }.sorted()
+        let selected = proofIndices.map { proofs[$0] }
+        let fee = state.fee
+        let net = state.net
+        let change = net - target
+        return ProofSelectionResult(kind: .mintTransaction,
+                                    selected: selected,
+                                    inputFee: fee,
+                                    netAmount: net,
+                                    changeAmount: change,
+                                    sendOutputAmounts: splitIntoBase2Numbers(target),
+                                    changeOutputAmounts: change > 0 ? splitIntoBase2Numbers(change) : [],
+                                    blankOutputAmounts: [],
+                                    keysetIDsSpent: Set(selected.map { $0.keysetID }),
+                                    optimality: optimality)
+    }
+
+    // MARK: - Helpers
+
+    /// Stable per-proof tie-break: `SHA256(seed ‖ keysetID ‖ C)`, first 8 bytes.
+    private static func tieBreakValue(seed: Data, keysetID: String, C: String) -> UInt64 {
+        var hasher = SHA256()
+        hasher.update(data: seed)
+        hasher.update(data: Data(keysetID.utf8))
+        hasher.update(data: Data(C.utf8))
+        var value: UInt64 = 0
+        for byte in hasher.finalize().prefix(8) { value = (value << 8) | UInt64(byte) }
+        return value
+    }
+
+    /// Lexicographic `<` for equal-purpose index lists (ultimate tie-break to
+    /// guarantee a fully deterministic winner regardless of dictionary order).
+    private static func lexLess(_ a: [Int], _ b: [Int]) -> Bool {
+        for (x, y) in zip(a, b) where x != y { return x < y }
+        return a.count < b.count
+    }
+}

--- a/Sources/cashu-swift/Operations/ProofSelection.swift
+++ b/Sources/cashu-swift/Operations/ProofSelection.swift
@@ -169,6 +169,13 @@ extension CashuSwift {
     ///   - unit: The unit being spent (e.g. `"sat"`).
     ///   - purpose: Drives direct-vs-mint-transaction behaviour.
     ///   - policy: Tie-breaking knobs and guardrails.
+    ///   - denominationTarget: Optional offline-optimization shape. When supplied,
+    ///     selection moves toward the target in *both* directions: it prefers
+    ///     spending over-represented (surplus) denominations as a low-priority
+    ///     tie-breaker (never overriding fee/change/count), and it shapes
+    ///     `changeOutputAmounts` to fill the wallet's denomination deficits instead
+    ///     of a plain base-2 split. `nil` reproduces the prior base-2 behaviour
+    ///     exactly. See `DistributionPlanning.swift`.
     /// - Returns: A `ProofSelectionResult` over the caller's proof type.
     /// - Throws: `ProofSelectionError` on infeasible / invalid / stale-keyset input.
     public static func selectProofs<P: ProofRepresenting>(
@@ -177,7 +184,8 @@ extension CashuSwift {
         mint: some MintRepresenting,
         unit: String,
         purpose: ProofSelectionPurpose,
-        policy: ProofSelectionPolicy = .default
+        policy: ProofSelectionPolicy = .default,
+        denominationTarget: DenominationTarget? = nil
     ) throws -> ProofSelectionResult<P> {
 
         guard targetAmount >= 0 else { throw ProofSelectionError.invalidTarget }
@@ -190,6 +198,21 @@ extension CashuSwift {
                                         netAmount: 0, changeAmount: 0, sendOutputAmounts: [],
                                         changeOutputAmounts: [], blankOutputAmounts: [],
                                         keysetIDsSpent: [], optimality: .provedOptimal)
+        }
+
+        // Optional denomination-target context: the power-of-two basis used to shape
+        // change outputs toward the wallet's ideal distribution. Absent ⇒
+        // `changeOverride` nil ⇒ identical to the prior base-2 behaviour.
+        //
+        // Note: the target deliberately does *not* bias input selection. For
+        // power-of-two denominations the selector's optimum is essentially unique in
+        // (fee, change, count, amount), so a "drain surplus" input tie-breaker would
+        // almost never fire yet would widen the Stage-2 Pareto frontier. The surplus
+        // direction is handled where it can act without sacrificing optimality: a
+        // wallet-initiated consolidation swap (see `idealDistribution` /
+        // `denominationGap`). Here we only shape the change *outputs* (deficit fill).
+        let plan = denominationTarget.map {
+            denominationPlan(eligible: eligible, mint: mint, unit: unit, target: $0)
         }
 
         // Stage 1 — exact, fee-free direct subset.
@@ -209,8 +232,61 @@ extension CashuSwift {
         let eligibleRaw = eligible.reduce(0) { $0 + $1.amount }
         let outcome = try feeAwareSubset(mintItems, target: targetAmount, policy: policy,
                                          eligibleRawAmount: eligibleRaw, purpose: purpose)
+
+        let changeOverride = plan.map {
+            changeOutputDistribution(state: outcome.state, items: mintItems,
+                                     eligible: eligible, target: targetAmount, plan: $0)
+        }
         return mintResult(outcome.state, optimality: outcome.optimality,
-                          items: mintItems, proofs: proofs, target: targetAmount, purpose: purpose)
+                          items: mintItems, proofs: proofs, target: targetAmount,
+                          purpose: purpose, changeOutputAmountsOverride: changeOverride)
+    }
+
+    // MARK: - Denomination-target planning (offline-send optimization)
+
+    /// The power-of-two basis (and target) used to shape change outputs toward the
+    /// wallet's ideal denomination distribution.
+    private struct DenominationPlan {
+        let target: DenominationTarget
+        let basis: [Int]
+    }
+
+    /// Resolves the basis to plan over from the eligible (this-mint/unit) inventory:
+    /// the active keyset's supported denominations capped at the inventory's top bit,
+    /// or synthesized powers of two if no keyset enumerates them.
+    private static func denominationPlan(eligible: [EligibleProof],
+                                         mint: some MintRepresenting,
+                                         unit: String,
+                                         target: DenominationTarget) -> DenominationPlan {
+        let balance = eligible.reduce(0) { $0 + $1.amount }
+        let cap = target.maxDenomination ?? topBitDenomination(balance)
+        let basis = activeKeysetForUnit(unit, mint: mint).map { denominationBasis(keyset: $0, cap: cap) }
+                    ?? powersOfTwo(upTo: cap)
+        return DenominationPlan(target: target, basis: basis)
+    }
+
+    /// The change-output split that best fills the wallet's denomination deficits,
+    /// given the inventory it retains after spending `state`'s inputs. Empty when
+    /// there is no change. Sums exactly to the change amount (so it can feed a
+    /// `preferredReturnDistribution` without a mismatch).
+    private static func changeOutputDistribution(state: SelectionState,
+                                                 items: [SelectionItem],
+                                                 eligible: [EligibleProof],
+                                                 target: Int,
+                                                 plan: DenominationPlan) -> [Int] {
+        let change = state.net - target
+        guard change > 0 else { return [] }
+        let spent = Set(state.chosen.flatMap { items[$0].indices })
+        var retained: [Int: Int] = [:]
+        var retainedSum = 0
+        for e in eligible where !spent.contains(e.index) {
+            retained[e.amount, default: 0] += 1
+            retainedSum += e.amount
+        }
+        let ideal = idealCounts(balance: retainedSum + change, target: plan.target,
+                                denominations: plan.basis)
+        return fillDistribution(amount: change, retained: retained, ideal: ideal,
+                                denominations: plan.basis)
     }
 
     // MARK: - Eligibility & keyset resolution
@@ -541,20 +617,24 @@ extension CashuSwift {
 
     private static func mintResult<P: ProofRepresenting>(
         _ state: SelectionState, optimality: ProofSelectionOptimality,
-        items: [SelectionItem], proofs: [P], target: Int, purpose: ProofSelectionPurpose
+        items: [SelectionItem], proofs: [P], target: Int, purpose: ProofSelectionPurpose,
+        changeOutputAmountsOverride: [Int]? = nil
     ) -> ProofSelectionResult<P> {
         let proofIndices = state.chosen.flatMap { items[$0].indices }.sorted()
         let selected = proofIndices.map { proofs[$0] }
         let fee = state.fee
         let net = state.net
         let change = net - target
+        // Use the target-aware change split when supplied; otherwise the base-2 split.
+        let changeOutputAmounts = changeOutputAmountsOverride
+            ?? (change > 0 ? splitIntoBase2Numbers(change) : [])
         return ProofSelectionResult(kind: .mintTransaction,
                                     selected: selected,
                                     inputFee: fee,
                                     netAmount: net,
                                     changeAmount: change,
                                     sendOutputAmounts: splitIntoBase2Numbers(target),
-                                    changeOutputAmounts: change > 0 ? splitIntoBase2Numbers(change) : [],
+                                    changeOutputAmounts: changeOutputAmounts,
                                     blankOutputAmounts: [],
                                     keysetIDsSpent: Set(selected.map { $0.keysetID }),
                                     optimality: optimality)

--- a/Sources/cashu-swift/Operations/ProofSelection.swift
+++ b/Sources/cashu-swift/Operations/ProofSelection.swift
@@ -26,8 +26,8 @@
 //      (in which case optimality is reported truthfully).
 //
 //  NUT-02 input fees: fee(S) = ceil( Σ inputFeePPK(S) / 1000 ), paid only when
-//  a mint transaction (swap/melt/receive/…) is required — never for a direct
-//  token send of existing proofs.
+//  the selected proofs are spent in a swap or melt — never for a direct token
+//  send of existing proofs.
 //
 
 import Foundation
@@ -51,8 +51,8 @@ extension CashuSwift {
 
         /// Whether an exact, fee-free subset of existing proofs may satisfy the
         /// request. Only an unlocked direct transfer can be fulfilled without a
-        /// mint transaction; every other purpose mints new outputs and pays the
-        /// NUT-02 input fee.
+        /// swap or melt; every other purpose creates new outputs via a swap and
+        /// pays the NUT-02 input fee.
         var allowsDirectExact: Bool { self == .tokenTransferUnlocked }
     }
 
@@ -64,10 +64,10 @@ extension CashuSwift {
         /// Try an exact, fee-free direct subset before fee-aware selection
         /// (only consulted for purposes whose `allowsDirectExact` is true).
         public var preferDirectExact: Bool
-        /// For mint transactions, break otherwise-equal candidates by spending
+        /// For swaps and melts, break otherwise-equal candidates by spending
         /// *inactive* keysets first (keyset hygiene). Never overrides
         /// fee/change/count/amount.
-        public var preferInactiveKeysetsForMintTransactions: Bool
+        public var preferInactiveKeysetsForSwaps: Bool
         /// For direct sends, break otherwise-equal candidates by keeping the
         /// recipient on *active* keysets. Never overrides proof-count/fee order.
         public var avoidInactiveKeysetsForDirectSend: Bool
@@ -83,13 +83,13 @@ extension CashuSwift {
         public var randomSeed: Data
 
         public init(preferDirectExact: Bool = true,
-                    preferInactiveKeysetsForMintTransactions: Bool = false,
+                    preferInactiveKeysetsForSwaps: Bool = false,
                     avoidInactiveKeysetsForDirectSend: Bool = false,
                     maxStates: Int? = 200_000,
                     bestEffortWhenStateLimitHit: Bool = false,
                     randomSeed: Data = Data()) {
             self.preferDirectExact = preferDirectExact
-            self.preferInactiveKeysetsForMintTransactions = preferInactiveKeysetsForMintTransactions
+            self.preferInactiveKeysetsForSwaps = preferInactiveKeysetsForSwaps
             self.avoidInactiveKeysetsForDirectSend = avoidInactiveKeysetsForDirectSend
             self.maxStates = maxStates
             self.bestEffortWhenStateLimitHit = bestEffortWhenStateLimitHit
@@ -99,9 +99,9 @@ extension CashuSwift {
         public static let `default` = ProofSelectionPolicy()
     }
 
-    /// Whether the result is a direct token send (no mint interaction) or a
-    /// mint transaction (swap/melt) the caller must execute.
-    public enum ProofSelectionKind: Sendable, Equatable { case directToken, mintTransaction }
+    /// Whether the result is a direct token send (no mint round-trip) or a swap —
+    /// i.e. a swap or melt the caller must execute to produce the new outputs.
+    public enum ProofSelectionKind: Sendable, Equatable { case directToken, swap }
 
     /// Whether the selection is mathematically proven optimal under the
     /// comparator, or a best-effort result returned because the state cap hit.
@@ -167,7 +167,7 @@ extension CashuSwift {
     ///     reproduces `Σ ≥ amount + feeReserve + inputFee`.
     ///   - mint: Source of per-keyset fee rates and active/inactive status.
     ///   - unit: The unit being spent (e.g. `"sat"`).
-    ///   - purpose: Drives direct-vs-mint-transaction behaviour.
+    ///   - purpose: Drives direct-vs-swap behaviour.
     ///   - policy: Tie-breaking knobs and guardrails.
     ///   - denominationTarget: Optional offline-optimization shape. When supplied,
     ///     selection moves toward the target in *both* directions: it prefers
@@ -225,20 +225,20 @@ extension CashuSwift {
             }
         }
 
-        // Stage 2 — fee-aware bounded knapsack (mint transaction).
-        let mintItems = bundle(eligible,
-                               scoreForActive: mintScorer(policy),
+        // Stage 2 — fee-aware bounded knapsack (swap / melt).
+        let feeAwareItems = bundle(eligible,
+                               scoreForActive: feeAwareScorer(policy),
                                dropFeeDominated: true)
         let eligibleRaw = eligible.reduce(0) { $0 + $1.amount }
-        let outcome = try feeAwareSubset(mintItems, target: targetAmount, policy: policy,
+        let outcome = try feeAwareSubset(feeAwareItems, target: targetAmount, policy: policy,
                                          eligibleRawAmount: eligibleRaw, purpose: purpose)
 
         let changeOverride = plan.map {
-            changeOutputDistribution(state: outcome.state, items: mintItems,
+            changeOutputDistribution(state: outcome.state, items: feeAwareItems,
                                      eligible: eligible, target: targetAmount, plan: $0)
         }
-        return mintResult(outcome.state, optimality: outcome.optimality,
-                          items: mintItems, proofs: proofs, target: targetAmount,
+        return feeAwareResult(outcome.state, optimality: outcome.optimality,
+                          items: feeAwareItems, proofs: proofs, target: targetAmount,
                           purpose: purpose, changeOutputAmountsOverride: changeOverride)
     }
 
@@ -413,8 +413,8 @@ extension CashuSwift {
         policy.avoidInactiveKeysetsForDirectSend ? { $0 ? 0 : 1 } : { _ in 0 }
     }
 
-    private static func mintScorer(_ policy: ProofSelectionPolicy) -> (Bool) -> Int {
-        policy.preferInactiveKeysetsForMintTransactions ? { $0 ? 1 : 0 } : { _ in 0 }
+    private static func feeAwareScorer(_ policy: ProofSelectionPolicy) -> (Bool) -> Int {
+        policy.preferInactiveKeysetsForSwaps ? { $0 ? 1 : 0 } : { _ in 0 }
     }
 
     // MARK: - DP state
@@ -480,7 +480,7 @@ extension CashuSwift {
 
     // MARK: - Stage 2: fee-aware bounded knapsack
 
-    /// Fee-aware Pareto DP. Finds the selection minimising the mint-transaction
+    /// Fee-aware Pareto DP. Finds the selection minimising the swap
     /// comparator subject to `net ≥ target`.
     private static func feeAwareSubset(_ items: [SelectionItem],
                                        target: Int,
@@ -504,7 +504,7 @@ extension CashuSwift {
         // heuristics, falling back to the guaranteed-feasible all-items state.
         var best = allState
         for seed in heuristicSeeds(items, target: target) {
-            if mintBetter(seed, than: best, target: target) { best = seed }
+            if feeAwareBetter(seed, than: best, target: target) { best = seed }
         }
 
         // states[amount] = Pareto-minimal open (net < target) states at `amount`.
@@ -522,7 +522,7 @@ extension CashuSwift {
                     if candidate.net >= target {
                         // Feasible: evaluate, but do not extend — extension only
                         // raises amount/ppk/count, never lowering fee or change.
-                        if mintBetter(candidate, than: best, target: target) { best = candidate }
+                        if feeAwareBetter(candidate, than: best, target: target) { best = candidate }
                     } else {
                         insertPareto(candidate, into: &states[candidate.amount, default: []],
                                      stateCount: &stateCount)
@@ -582,9 +582,9 @@ extension CashuSwift {
         a.ppk <= b.ppk && a.proofCount <= b.proofCount && a.keysetScore <= b.keysetScore
     }
 
-    /// Mint-transaction comparator: lowest fee, then change, then proof count,
+    /// Swap comparator: lowest fee, then change, then proof count,
     /// then raw amount, then keyset hygiene, then a stable tie-break.
-    private static func mintBetter(_ a: SelectionState, than b: SelectionState, target: Int) -> Bool {
+    private static func feeAwareBetter(_ a: SelectionState, than b: SelectionState, target: Int) -> Bool {
         let af = a.fee, bf = b.fee
         if af != bf { return af < bf }
         let ac = a.net - target, bc = b.net - target
@@ -615,7 +615,7 @@ extension CashuSwift {
                                     optimality: .provedOptimal)
     }
 
-    private static func mintResult<P: ProofRepresenting>(
+    private static func feeAwareResult<P: ProofRepresenting>(
         _ state: SelectionState, optimality: ProofSelectionOptimality,
         items: [SelectionItem], proofs: [P], target: Int, purpose: ProofSelectionPurpose,
         changeOutputAmountsOverride: [Int]? = nil
@@ -628,7 +628,7 @@ extension CashuSwift {
         // Use the target-aware change split when supplied; otherwise the base-2 split.
         let changeOutputAmounts = changeOutputAmountsOverride
             ?? (change > 0 ? splitIntoBase2Numbers(change) : [])
-        return ProofSelectionResult(kind: .mintTransaction,
+        return ProofSelectionResult(kind: .swap,
                                     selected: selected,
                                     inputFee: fee,
                                     netAmount: net,

--- a/Sources/cashu-swift/Operations/SwapOperations.swift
+++ b/Sources/cashu-swift/Operations/SwapOperations.swift
@@ -20,7 +20,11 @@ extension CashuSwift {
     ///   - mint: The mint to swap with
     ///   - amount: Optional amount to swap (if nil, swaps all minus fees)
     ///   - seed: Optional seed for deterministic secret generation
-    ///   - preferredReturnDistribution: Optional preferred denomination distribution for change
+    ///   - preferredReturnDistribution: Optional preferred denomination distribution. When
+    ///     `amount` is non-nil it shapes the *change* (must sum to the change amount); when
+    ///     `amount` is nil (keep everything) it shapes the *entire returned pool* (must sum
+    ///     to `proofSum − fee`) — used for receive- and consolidation-time rebalancing.
+    ///     A mismatch throws `preferredDistributionMismatch`.
     /// - Returns: A tuple containing:
     ///   - new: The new proofs
     ///   - change: The change proofs
@@ -62,19 +66,36 @@ extension CashuSwift {
             throw CashuError.noActiveKeysetForUnit("no active keyset could be found for unit \(unit)")
         }
         
-        let swapDistribution = CashuSwift.splitIntoBase2Numbers(returnAmount)
-        
-        let changeDistribution = preferredReturnDistribution.map({ $0 }) ?? splitIntoBase2Numbers(changeAmount)
-        
-        guard changeDistribution.reduce(0, +) == changeAmount else {
-            throw CashuError.preferredDistributionMismatch(
-            """
-            preferredReturnDistribution does not add up to expected change amount.
-            proof sum: \(proofSum), return amount: \(returnAmount), change amount: \
-            \(changeAmount), fees: \(fee), preferred distr sum: \(changeDistribution.reduce(0, +))
-            """)
+        let swapDistribution: [Int]
+        let changeDistribution: [Int]
+
+        if amount == nil {
+            // No send portion: the whole returned pool is kept, so a preferred
+            // distribution (if given) shapes all of it — enabling receive- and
+            // consolidation-time rebalancing toward a denomination target.
+            swapDistribution = preferredReturnDistribution ?? splitIntoBase2Numbers(returnAmount)
+            changeDistribution = []
+            guard swapDistribution.reduce(0, +) == returnAmount else {
+                throw CashuError.preferredDistributionMismatch(
+                """
+                preferredReturnDistribution does not add up to the returned amount.
+                proof sum: \(proofSum), return amount: \(returnAmount), fees: \(fee), \
+                preferred distr sum: \(swapDistribution.reduce(0, +))
+                """)
+            }
+        } else {
+            swapDistribution = CashuSwift.splitIntoBase2Numbers(returnAmount)
+            changeDistribution = preferredReturnDistribution ?? splitIntoBase2Numbers(changeAmount)
+            guard changeDistribution.reduce(0, +) == changeAmount else {
+                throw CashuError.preferredDistributionMismatch(
+                """
+                preferredReturnDistribution does not add up to expected change amount.
+                proof sum: \(proofSum), return amount: \(returnAmount), change amount: \
+                \(changeAmount), fees: \(fee), preferred distr sum: \(changeDistribution.reduce(0, +))
+                """)
+            }
         }
-        
+
         let combinedDistribution = (swapDistribution + changeDistribution).sorted()
         
         let deterministicFactors = seed.map({ ($0, activeKeyset.derivationCounter) })

--- a/Sources/cashu-swift/Operations/receive.swift
+++ b/Sources/cashu-swift/Operations/receive.swift
@@ -15,13 +15,18 @@ extension CashuSwift {
     ///   - mint: The mint to receive with via swap operation (must be same as in token)
     ///   - seed: Optional seed for deterministic secret generation
     ///   - privateKey: Optional hex string of 32-byte Schnorr private key for unlocking P2PK-locked tokens
+    ///   - preferredReturnDistribution: Optional denomination split for the received
+    ///     proofs, e.g. from `preferredDistribution(forAmount:retained:…)` to move the
+    ///     wallet toward its offline-send denomination target. Must sum to the received
+    ///     amount net of input fees, or `preferredDistributionMismatch` is thrown.
     ///
     /// - Returns: A `ReceiveResult` containing the received proofs and DLEQ verification results
     /// - Throws: An error if the receive operation fails
     public static func receive(token: Token,
                                of mint: Mint,
                                seed: String?,
-                               privateKey: String?) async throws -> ReceiveResult {
+                               privateKey: String?,
+                               preferredReturnDistribution: [Int]? = nil) async throws -> ReceiveResult {
         
         // this should check whether proofs are from this mint and not multi unit FIXME: potentially wonky and not very descriptive
         guard token.proofsByMint.count == 1 else {
@@ -84,7 +89,8 @@ extension CashuSwift {
             break
         }
         
-        let swapResult = try await swap(inputs: inputProofs, with: mint, seed: seed)
+        let swapResult = try await swap(inputs: inputProofs, with: mint, seed: seed,
+                                        preferredReturnDistribution: preferredReturnDistribution)
         return ReceiveResult(proofs: swapResult.new,
                              inputDLEQ: swapResult.inputDLEQ,
                              outputDLEQ: swapResult.outputDLEQ)

--- a/Sources/cashu-swift/Operations/send.swift
+++ b/Sources/cashu-swift/Operations/send.swift
@@ -24,6 +24,12 @@ extension CashuSwift {
     ///   - seed: Optional seed for deterministic secret generation. If `lockToPublicKey` is present, only change will be deterministic
     ///   - memo: Optional memo to include in the token
     ///   - lockToPublicKey: Optional Schnorr public key in compressed 33-byte format to lock the token to
+    ///   - preferredKeepDistribution: Optional denomination split for the change (kept)
+    ///     proofs, e.g. from `preferredDistribution(forAmount:retained:…)` to move the
+    ///     wallet toward its offline-send denomination target. Must sum to the keep
+    ///     amount or `preferredDistributionMismatch` is thrown. The send (token) outputs
+    ///     stay base-2 — their denominations are the recipient's concern. Ignored on the
+    ///     exact-amount direct path (no swap, no change).
     ///
     /// - Returns: A `SendResult` containing the token, change proofs, DLEQ verification result, and counter increase info
     /// - Throws: An error if the operation fails
@@ -32,7 +38,8 @@ extension CashuSwift {
                             amount: Int? = nil,
                             seed: String?,
                             memo: String? = nil,
-                            lockToPublicKey: String? = nil) async throws -> SendResult {
+                            lockToPublicKey: String? = nil,
+                            preferredKeepDistribution: [Int]? = nil) async throws -> SendResult {
         let proofSum = sum(inputs)
         let inputFee = try calculateFee(for: inputs, of: mint)
         
@@ -65,12 +72,17 @@ extension CashuSwift {
         }
         
         let split = try split(for: proofSum, target: amount, fee: inputFee)
-        
-        let keepOutputSets = try generateOutputs(distribution: splitIntoBase2Numbers(split.keepAmount),
+
+        let keepDistribution = preferredKeepDistribution ?? splitIntoBase2Numbers(split.keepAmount)
+        guard keepDistribution.reduce(0, +) == split.keepAmount else {
+            throw CashuError.preferredDistributionMismatch(
+                "preferredKeepDistribution sum (\(keepDistribution.reduce(0, +))) does not match the keep amount (\(split.keepAmount)).")
+        }
+        let keepOutputSets = try generateOutputs(distribution: keepDistribution,
                                                  mint: mint,
                                                  seed: seed,
                                                  unit: unit)
-                
+
         let sendOutputSets = try lockToPublicKey.map { pubkey in
             try generateP2PKOutputs(for: split.sendAmount,
                                     mint: mint,
@@ -108,7 +120,8 @@ extension CashuSwift {
                             inputs: [Proof],
                             amount: Int? = nil,
                             memo: String?,
-                            seed: String?) async throws -> SendPayloadResult {
+                            seed: String?,
+                            preferredKeepDistribution: [Int]? = nil) async throws -> SendPayloadResult {
         
         guard let requestAmount = request.amount ?? amount else {
             throw CashuError.paymentRequestAmount("Either request amount or explicit amount must be provided")
@@ -147,8 +160,13 @@ extension CashuSwift {
         }
         
         let split = try split(for: proofSum, target: requestAmount, fee: inputFee)
-        
-        let keepOutputSets = try generateOutputs(distribution: splitIntoBase2Numbers(split.keepAmount),
+
+        let keepDistribution = preferredKeepDistribution ?? splitIntoBase2Numbers(split.keepAmount)
+        guard keepDistribution.reduce(0, +) == split.keepAmount else {
+            throw CashuError.preferredDistributionMismatch(
+                "preferredKeepDistribution sum (\(keepDistribution.reduce(0, +))) does not match the keep amount (\(split.keepAmount)).")
+        }
+        let keepOutputSets = try generateOutputs(distribution: keepDistribution,
                                                  mint: mint,
                                                  seed: seed,
                                                  unit: unit)
@@ -185,5 +203,58 @@ extension CashuSwift {
                                  change: swapResult.keep,
                                  outputDLEQ: swapResult.outputDLEQ,
                                  counterIncrease: (activeKeyset.keysetID, increase))
+    }
+
+    /// Builds a token from exactly the given proofs, with **no mint round-trip**.
+    ///
+    /// This is the offline-send primitive. When the wallet already holds a subset of
+    /// unlocked proofs summing to the desired amount — e.g. a
+    /// `selectProofs(…, purpose: .tokenTransferUnlocked)` result whose `kind` is
+    /// `.directToken` — the token simply *is* those proofs: no swap, no change, no
+    /// network. Being **synchronous**, the absence of a network round-trip is
+    /// guaranteed at the type level (unlike the `async` `send`).
+    ///
+    /// The caller owns proof-state handling: reserve/mark the proofs `pending` before
+    /// handing off the token, since they now leave the wallet's spendable balance.
+    ///
+    /// - Parameters:
+    ///   - proofs: The exact proofs to bundle. Must share a single unit and carry no
+    ///     spending condition — a P2PK send must mint outputs to the lock key, which
+    ///     requires the mint and so cannot be done offline.
+    ///   - mint: The mint these proofs belong to (provides the URL and keyset IDs).
+    ///   - memo: Optional memo to include in the token.
+    /// - Returns: A `Token` bundling `proofs`.
+    /// - Throws: `CashuError` if `proofs` is empty, spans multiple units, or is locked.
+    public static func offlineToken(for proofs: [Proof],
+                                    mint: Mint,
+                                    memo: String? = nil) throws -> Token {
+        guard !proofs.isEmpty else {
+            throw CashuError.insufficientInputs("offlineToken: no proofs provided.")
+        }
+        let unit = try singleUnit(for: proofs, of: mint)
+        for p in proofs {
+            guard SpendingCondition.deserialize(from: p.secret) == nil else {
+                throw CashuError.spendingConditionError("offlineToken does not support locked proofs.")
+            }
+        }
+        return Token(proofs: [mint.url.absoluteString: proofs.withShortKeysetID()],
+                     unit: unit,
+                     memo: memo)
+    }
+
+    /// Whether `amount` can be sent offline (unlocked) right now: i.e. an exact subset
+    /// of `proofs` sums to it, so a token can be built with `offlineToken(for:…)`
+    /// without a mint swap. Convenience over inspecting
+    /// `selectProofs(…, purpose: .tokenTransferUnlocked).kind == .directToken`.
+    /// Returns `false` on any infeasibility (insufficient funds, no eligible proofs, …).
+    public static func canSendOffline(_ proofs: [some ProofRepresenting],
+                                      amount: Int,
+                                      mint: some MintRepresenting,
+                                      unit: String) -> Bool {
+        guard let result = try? selectProofs(proofs, targetAmount: amount, mint: mint,
+                                             unit: unit, purpose: .tokenTransferUnlocked) else {
+            return false
+        }
+        return result.kind == .directToken
     }
 }

--- a/Tests/cashu-swiftTests/DistributionPlanningTests.swift
+++ b/Tests/cashu-swiftTests/DistributionPlanningTests.swift
@@ -1,0 +1,450 @@
+//
+//  DistributionPlanningTests.swift
+//  CashuSwiftTests
+//
+//  Pure unit tests for the denomination-distribution planner — no network.
+//  Covers the helpers, the ideal-shape / fill / gap algorithms, their exact-sum
+//  and valid-denomination invariants, the both-directions gap metric, degenerate
+//  inputs, keyset-driven denomination caps, and randomized property tests.
+//
+
+import XCTest
+@testable import CashuSwift
+
+// MARK: - Fixtures
+
+/// Builds a `Keyset` whose `keys` enumerate the given denominations (decoding
+/// minimal JSON — the model has a custom `Decodable` init and no memberwise init).
+private func keyset(denominations: [Int] = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512,
+                                            1024, 2048, 4096, 8192, 16384, 32768,
+                                            65536, 131072, 262144, 524288, 1048576],
+                    id: String = "00deadbeef0000",
+                    unit: String = "sat",
+                    active: Bool = true) -> CashuSwift.Keyset {
+    let keysJSON = denominations.map { "\"\($0)\":\"02aa\"" }.joined(separator: ",")
+    let json = """
+    {"id":"\(id)","unit":"\(unit)","active":\(active),"input_fee_ppk":0,"keys":{\(keysJSON)}}
+    """
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+/// A keyset with the empty-string placeholder keys (state before keys are loaded).
+private func placeholderKeyset() -> CashuSwift.Keyset {
+    let json = #"{"id":"00deadbeef0000","unit":"sat","active":true,"input_fee_ppk":0}"#
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+/// A minimal wallet-side proof type.
+private struct P: ProofRepresenting {
+    let keysetID: String
+    let C: String
+    let secret: String
+    let amount: Int
+    let dleq: CashuSwift.DLEQ?
+}
+
+private func proofs(_ amounts: [Int], keysetID: String = "00deadbeef0000") -> [P] {
+    amounts.enumerated().map {
+        P(keysetID: keysetID, C: "C\($0.offset)", secret: "s\($0.offset)",
+          amount: $0.element, dleq: nil)
+    }
+}
+
+private func isPowerOfTwo(_ n: Int) -> Bool { n > 0 && (n & (n - 1)) == 0 }
+private func sum(_ xs: [Int]) -> Int { xs.reduce(0, +) }
+
+/// SplitMix64 — deterministic RNG for property tests.
+private struct SeededRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+final class DistributionPlanningTests: XCTestCase {
+
+    private let fullKeyset = keyset()
+
+    // MARK: - Helpers: powersOfTwo / topBitDenomination
+
+    func testPowersOfTwo() {
+        XCTAssertEqual(CashuSwift.powersOfTwo(upTo: 0), [])
+        XCTAssertEqual(CashuSwift.powersOfTwo(upTo: 1), [1])
+        XCTAssertEqual(CashuSwift.powersOfTwo(upTo: 7), [1, 2, 4])
+        XCTAssertEqual(CashuSwift.powersOfTwo(upTo: 8), [1, 2, 4, 8])
+        XCTAssertEqual(CashuSwift.powersOfTwo(upTo: 100), [1, 2, 4, 8, 16, 32, 64])
+    }
+
+    func testTopBitDenomination() {
+        XCTAssertEqual(CashuSwift.topBitDenomination(0), 0)
+        XCTAssertEqual(CashuSwift.topBitDenomination(-5), 0)
+        XCTAssertEqual(CashuSwift.topBitDenomination(1), 1)
+        XCTAssertEqual(CashuSwift.topBitDenomination(2), 2)
+        XCTAssertEqual(CashuSwift.topBitDenomination(3), 2)
+        XCTAssertEqual(CashuSwift.topBitDenomination(7), 4)
+        XCTAssertEqual(CashuSwift.topBitDenomination(8), 8)
+        XCTAssertEqual(CashuSwift.topBitDenomination(5000), 4096)
+        XCTAssertEqual(CashuSwift.topBitDenomination(1 << 40), 1 << 40)
+    }
+
+    // MARK: - Helpers: counts / flatten
+
+    func testCountsBucketsByAmountAndIgnoresZero() {
+        let c = CashuSwift.counts(of: proofs([1, 1, 2, 4, 4, 4, 0]))
+        XCTAssertEqual(c, [1: 2, 2: 1, 4: 3])
+    }
+
+    func testCountsEmpty() {
+        XCTAssertEqual(CashuSwift.counts(of: [P]()), [:])
+    }
+
+    func testFlattenAscendingWithRepetition() {
+        XCTAssertEqual(CashuSwift.flatten([4: 2, 1: 3, 2: 1]), [1, 1, 1, 2, 4, 4])
+        XCTAssertEqual(CashuSwift.flatten([:]), [])
+        XCTAssertEqual(CashuSwift.flatten([8: 0, 2: 1]), [2])   // zero counts dropped
+    }
+
+    func testCountsFlattenRoundTrip() {
+        let amounts = [1, 1, 1, 2, 8, 8, 64]
+        XCTAssertEqual(CashuSwift.flatten(CashuSwift.counts(of: proofs(amounts))), amounts.sorted())
+    }
+
+    // MARK: - Helpers: supportedDenominations / denominationBasis
+
+    func testSupportedDenominationsParsesPowersOfTwo() {
+        XCTAssertEqual(CashuSwift.supportedDenominations(of: keyset(denominations: [1, 2, 4, 8, 16])),
+                       [1, 2, 4, 8, 16])
+    }
+
+    func testSupportedDenominationsFiltersNonPowersOfTwoAndPlaceholder() {
+        // 3, 5, 6 are not powers of two and must be dropped; placeholder "" too.
+        let ks = keyset(denominations: [1, 2, 3, 4, 5, 6, 8])
+        XCTAssertEqual(CashuSwift.supportedDenominations(of: ks), [1, 2, 4, 8])
+        XCTAssertEqual(CashuSwift.supportedDenominations(of: placeholderKeyset()), [])
+    }
+
+    func testDenominationBasisAppliesCap() {
+        XCTAssertEqual(CashuSwift.denominationBasis(keyset: fullKeyset, cap: 16), [1, 2, 4, 8, 16])
+    }
+
+    func testDenominationBasisFallsBackToPowersOfTwoWhenKeysetEmpty() {
+        // No usable keys ⇒ synthesize powers of two up to the cap (always includes 1).
+        XCTAssertEqual(CashuSwift.denominationBasis(keyset: placeholderKeyset(), cap: 8),
+                       [1, 2, 4, 8])
+    }
+
+    // MARK: - idealCounts / idealDistribution: hand-computed cases
+
+    func testIdealDistributionSmallBalances() {
+        // Small-first redundancy: tiny balances prefer multiple 1s over a single larger
+        // coin (more independent small offline payments), capped at N.
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 0, keyset: fullKeyset), [])
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 1, keyset: fullKeyset), [1])
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 2, keyset: fullKeyset), [1, 1])
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 3, keyset: fullKeyset), [1, 1, 1])
+        // balance 4: three deficit 1s (=3) + a remainder 1 ⇒ four 1s.
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 4, keyset: fullKeyset), [1, 1, 1, 1])
+        // balance 5: three 1s (=3) then a 2 fits the remainder ⇒ a 2 finally appears.
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 5, keyset: fullKeyset), [1, 1, 1, 2])
+    }
+
+    func testIdealDistributionN1MatchesBase2OnFullCovers() {
+        // For balance == 2^k - 1, one-of-each ascending reproduces the base-2 split.
+        let t = CashuSwift.DenominationTarget(countPerDenomination: 1)
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 7, target: t, keyset: fullKeyset),
+                       [1, 2, 4])
+        XCTAssertEqual(CashuSwift.idealDistribution(balance: 15, target: t, keyset: fullKeyset),
+                       [1, 2, 4, 8])
+    }
+
+    func testIdealCountsRedundancyOnSmallDenominations() {
+        // Large balance ⇒ small denominations reach the cap N, bulk lands on large denoms.
+        let basis = CashuSwift.powersOfTwo(upTo: 1024)
+        let ideal = CashuSwift.idealCounts(balance: 100_000,
+                                           target: CashuSwift.DenominationTarget(countPerDenomination: 3),
+                                           denominations: basis)
+        // Every small denomination is held at least N times.
+        for d in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512] {
+            XCTAssertGreaterThanOrEqual(ideal[d] ?? 0, 3, "expected ≥3 of denom \(d)")
+        }
+        // The largest denomination soaks up the remainder (far beyond N).
+        XCTAssertGreaterThan(ideal[1024] ?? 0, 3)
+        // Exact and within basis.
+        XCTAssertEqual(basis.reduce(0) { $0 + $1 * (ideal[$1] ?? 0) }, 100_000)
+    }
+
+    func testIdealDistributionRespectsKeysetMaxDenomination() {
+        // Keyset only offers up to 1024, but the balance's top bit is 8192.
+        let ks = keyset(denominations: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024])
+        let dist = CashuSwift.idealDistribution(balance: 10_000, keyset: ks)
+        XCTAssertEqual(sum(dist), 10_000)
+        XCTAssertTrue(dist.allSatisfy { $0 <= 1024 }, "must not exceed keyset's max denomination")
+        XCTAssertTrue(dist.allSatisfy(isPowerOfTwo))
+    }
+
+    func testIdealDistributionN0AbsorbsIntoLargestDenominations() {
+        // N = 0 disables the soft fill; remainder absorption is greedy descending.
+        let t = CashuSwift.DenominationTarget(countPerDenomination: 0)
+        let dist = CashuSwift.idealDistribution(balance: 100, target: t, keyset: fullKeyset)
+        XCTAssertEqual(sum(dist), 100)
+        XCTAssertEqual(dist, CashuSwift.splitIntoBase2Numbers(100).sorted())  // == minimal base-2
+    }
+
+    // MARK: - idealDistribution: invariants (property)
+
+    func testIdealDistributionExactSumAndValidDenoms_exhaustive() {
+        for n in [0, 1, 2, 3, 5, 8] {
+            let t = CashuSwift.DenominationTarget(countPerDenomination: n)
+            for balance in 0...512 {
+                let dist = CashuSwift.idealDistribution(balance: balance, target: t, keyset: fullKeyset)
+                XCTAssertEqual(sum(dist), balance, "N=\(n) balance=\(balance)")
+                let cap = CashuSwift.topBitDenomination(balance)
+                XCTAssertTrue(dist.allSatisfy { isPowerOfTwo($0) && $0 <= cap },
+                              "N=\(n) balance=\(balance) produced invalid denom in \(dist)")
+            }
+        }
+    }
+
+    func testIdealDistributionExactSum_randomLargeBalances() {
+        var rng = SeededRNG(seed: 0xA11CE)
+        for _ in 0..<2000 {
+            let balance = Int(rng.next() % 50_000_000)
+            let n = [1, 2, 3, 4, 6][Int(rng.next() % 5)]
+            let t = CashuSwift.DenominationTarget(countPerDenomination: n)
+            let dist = CashuSwift.idealDistribution(balance: balance, target: t, keyset: fullKeyset)
+            XCTAssertEqual(sum(dist), balance)
+            XCTAssertTrue(dist.allSatisfy(isPowerOfTwo))
+        }
+    }
+
+    /// End-to-end: a wallet holding *exactly* the ideal shape has zero gap.
+    func testIdealShapeHasZeroGap() {
+        for balance in [1, 7, 50, 100, 333, 1000, 99_999] {
+            let ideal = CashuSwift.idealDistribution(balance: balance, keyset: fullKeyset)
+            let gap = CashuSwift.denominationGap(for: proofs(ideal), keyset: fullKeyset)
+            XCTAssertEqual(gap.distance, 0, "balance=\(balance) ideal should be at target")
+            XCTAssertTrue(gap.deficits.isEmpty)
+            XCTAssertTrue(gap.surplus.isEmpty)
+        }
+    }
+
+    // MARK: - fillDistribution: hand-computed cases
+
+    func testFillFromEmptyReproducesIdeal() {
+        let ideal = [1: 3, 2: 3, 4: 3]                      // sum 21
+        let out = CashuSwift.fillDistribution(amount: 21, retained: [:], ideal: ideal,
+                                              denominations: [1, 2, 4, 8])
+        XCTAssertEqual(out, [1, 1, 1, 2, 2, 2, 4, 4, 4])
+    }
+
+    func testFillPrioritizesDeficitsSmallestFirst() {
+        // Need denom 1 (deficit 1), rest absorbed as fewest coins.
+        let out = CashuSwift.fillDistribution(amount: 3, retained: [:], ideal: [1: 1],
+                                              denominations: [1, 2, 4])
+        XCTAssertEqual(sum(out), 3)
+        XCTAssertEqual(out, [1, 2])   // one deficit-1, remainder 2 absorbed as a single 2
+    }
+
+    func testFillDoesNotPileOntoSurplusWhileDeficitsRemain() {
+        // denom 4 is already in heavy surplus; filling should target the deficits (1, 2)
+        // and never add another 4. Trace: three 1s + one 2 satisfy deficits (rem 1),
+        // then the trailing 1 sat can only be absorbed as a fourth 1.
+        let retained = [4: 10]
+        let ideal = [1: 3, 2: 3, 4: 3, 8: 3]
+        let out = CashuSwift.fillDistribution(amount: 6, retained: retained, ideal: ideal,
+                                              denominations: [1, 2, 4, 8])
+        XCTAssertEqual(sum(out), 6)
+        XCTAssertFalse(out.contains(4), "must not add to the already-surplus denom 4: \(out)")
+        XCTAssertEqual(CashuSwift.counts(of: proofs(out)), [1: 4, 2: 1])
+    }
+
+    func testFillRemainderStaysWithinBasis() {
+        // ideal capped at denom 4; a large amount must still decompose within [1,2,4].
+        let out = CashuSwift.fillDistribution(amount: 1000, retained: [:],
+                                              ideal: [1: 3, 2: 3, 4: 3],
+                                              denominations: [1, 2, 4])
+        XCTAssertEqual(sum(out), 1000)
+        XCTAssertTrue(out.allSatisfy { [1, 2, 4].contains($0) })
+    }
+
+    // MARK: - fillDistribution: invariants (property)
+
+    func testFillExactSumAndValidDenoms_random() {
+        var rng = SeededRNG(seed: 0xF111)
+        let basis = CashuSwift.powersOfTwo(upTo: 4096)
+        for _ in 0..<3000 {
+            // Random retained inventory.
+            var retained: [Int: Int] = [:]
+            for d in basis where rng.next() % 3 == 0 { retained[d] = Int(rng.next() % 6) }
+            let n = [1, 2, 3, 4][Int(rng.next() % 4)]
+            let retainedSum = retained.reduce(0) { $0 + $1.key * $1.value }
+            let amount = Int(rng.next() % 20_000) + 1
+            let ideal = CashuSwift.idealCounts(balance: retainedSum + amount,
+                                               target: CashuSwift.DenominationTarget(countPerDenomination: n),
+                                               denominations: basis)
+            let out = CashuSwift.fillDistribution(amount: amount, retained: retained,
+                                                  ideal: ideal, denominations: basis)
+            XCTAssertEqual(sum(out), amount)
+            XCTAssertTrue(out.allSatisfy { basis.contains($0) })
+        }
+    }
+
+    // MARK: - preferredDistribution (public)
+
+    func testPreferredDistributionExactSum() {
+        let out = CashuSwift.preferredDistribution(forAmount: 137,
+                                                   retained: proofs([1, 1, 64, 64]),
+                                                   keyset: fullKeyset)
+        XCTAssertEqual(sum(out), 137)
+        XCTAssertTrue(out.allSatisfy(isPowerOfTwo))
+    }
+
+    func testPreferredDistributionEmptyRetainedEqualsIdeal() {
+        for amount in [1, 13, 100, 4242] {
+            let pref = CashuSwift.preferredDistribution(forAmount: amount, retained: [P](),
+                                                        keyset: fullKeyset)
+            let ideal = CashuSwift.idealDistribution(balance: amount, keyset: fullKeyset)
+            XCTAssertEqual(pref, ideal, "amount=\(amount)")
+        }
+    }
+
+    func testPreferredDistributionZeroAmount() {
+        XCTAssertEqual(CashuSwift.preferredDistribution(forAmount: 0, retained: proofs([1, 2]),
+                                                        keyset: fullKeyset), [])
+    }
+
+    /// Universal invariant: minting `amount` new proofs via the preferred split
+    /// never *increases* any denomination's deficit, and reduces the total deficit
+    /// by at most `amount` (each filled deficit-coin costs ≥1 sat). Holds for every
+    /// retained inventory and amount — adding non-negative coins can only help.
+    func testPreferredFillIsMonotoneOnDeficit_random() {
+        var rng = SeededRNG(seed: 0x6A9)
+        for _ in 0..<3000 {
+            var retained: [Int: Int] = [:]
+            for d in CashuSwift.powersOfTwo(upTo: 4096) where rng.next() % 3 == 0 {
+                retained[d] = Int(rng.next() % 5)
+            }
+            let retainedProofs = proofs(CashuSwift.flatten(retained))
+            let amount = Int(rng.next() % 20_000) + 1
+
+            let out = CashuSwift.preferredDistribution(forAmount: amount,
+                                                       retained: retainedProofs, keyset: fullKeyset)
+            XCTAssertEqual(sum(out), amount)
+
+            // Same projected-balance ideal the planner used internally.
+            let retainedSum = retained.reduce(0) { $0 + $1.key * $1.value }
+            let ideal = CashuSwift.idealCounts(
+                balance: retainedSum + amount,
+                target: .default,
+                denominations: CashuSwift.denominationBasis(
+                    keyset: fullKeyset, cap: CashuSwift.topBitDenomination(retainedSum + amount)))
+            let outCounts = CashuSwift.counts(of: proofs(out))
+
+            func totalDeficit(_ have: [Int: Int]) -> Int {
+                ideal.reduce(0) { $0 + max(0, $1.value - (have[$1.key] ?? 0)) }
+            }
+            var combined = retained
+            for (d, c) in outCounts { combined[d, default: 0] += c }
+
+            let before = totalDeficit(retained)
+            let after = totalDeficit(combined)
+            XCTAssertLessThanOrEqual(after, before)              // never increases deficit
+            XCTAssertGreaterThanOrEqual(after, before - amount)  // can't over-fill
+        }
+    }
+
+    /// The motivating case: a wallet drained of small denominations (only large
+    /// coins) is moved *closer* to the ideal by the target-aware split than by a
+    /// plain base-2 split, because the fill rebuilds the depleted small coins while
+    /// base-2 of a power-of-two amount just mints one more large coin.
+    func testPreferredBeatsBase2WhenSmallDenominationsDepleted() {
+        let retained = proofs([512, 512, 512, 512])           // no small denominations
+        let amount = 8
+
+        let preferred = CashuSwift.preferredDistribution(forAmount: amount,
+                                                         retained: retained, keyset: fullKeyset)
+        let base2 = CashuSwift.splitIntoBase2Numbers(amount) // == [8]
+
+        XCTAssertEqual(sum(preferred), amount)
+        XCTAssertTrue(preferred.contains(1), "should rebuild depleted small denominations")
+
+        let gapPreferred = CashuSwift.denominationGap(for: retained + proofs(preferred),
+                                                      keyset: fullKeyset).distance
+        let gapBase2 = CashuSwift.denominationGap(for: retained + proofs(base2),
+                                                  keyset: fullKeyset).distance
+        XCTAssertLessThan(gapPreferred, gapBase2)
+    }
+
+    // MARK: - denominationGap: both directions
+
+    func testGapDetectsDeficits() {
+        // Only large coins held ⇒ small denominations are in deficit.
+        let gap = CashuSwift.denominationGap(for: proofs([64, 64, 64]), keyset: fullKeyset)
+        XCTAssertGreaterThan(gap.distance, 0)
+        XCTAssertFalse(gap.deficits.isEmpty)
+        XCTAssertGreaterThan(gap.deficits[1] ?? 0, 0, "should want some 1s it doesn't have")
+    }
+
+    func testGapDetectsSurplus() {
+        // Far more 1s than any sane target ⇒ surplus on denom 1.
+        let gap = CashuSwift.denominationGap(for: proofs(Array(repeating: 1, count: 50)),
+                                             keyset: fullKeyset)
+        XCTAssertGreaterThan(gap.surplus[1] ?? 0, 0)
+        XCTAssertGreaterThan(gap.distance, 0)
+    }
+
+    func testGapBothDirectionsSimultaneously() {
+        // Surplus of 4s, total deficit of small/other denoms.
+        let gap = CashuSwift.denominationGap(for: proofs(Array(repeating: 4, count: 20)),
+                                             keyset: fullKeyset)
+        XCTAssertFalse(gap.surplus.isEmpty, "20×4 over target on denom 4")
+        XCTAssertFalse(gap.deficits.isEmpty, "missing 1s/2s/etc.")
+        XCTAssertEqual(gap.distance,
+                       gap.deficits.values.reduce(0, +) + gap.surplus.values.reduce(0, +))
+    }
+
+    func testGapEmptyAndZeroBalance() {
+        XCTAssertEqual(CashuSwift.denominationGap(for: [P](), keyset: fullKeyset).distance, 0)
+        XCTAssertEqual(CashuSwift.denominationGap(for: proofs([0]), keyset: fullKeyset).distance, 0)
+    }
+
+    // MARK: - Degenerate keysets
+
+    func testPlanningWithPlaceholderKeysetStillExact() {
+        // Keys not loaded ⇒ basis falls back to powers of two; everything still sums.
+        let ks = placeholderKeyset()
+        XCTAssertEqual(sum(CashuSwift.idealDistribution(balance: 1234, keyset: ks)), 1234)
+        let pref = CashuSwift.preferredDistribution(forAmount: 555, retained: proofs([8, 8]), keyset: ks)
+        XCTAssertEqual(sum(pref), 555)
+    }
+
+    func testNonPowerOfTwoKeysetDenominationsIgnoredGracefully() {
+        // A keyset that (oddly) lists only non-powers-of-two ⇒ fall back, stay exact.
+        let ks = keyset(denominations: [3, 5, 6, 7])
+        XCTAssertEqual(CashuSwift.supportedDenominations(of: ks), [])
+        XCTAssertEqual(sum(CashuSwift.idealDistribution(balance: 99, keyset: ks)), 99)
+    }
+
+    // MARK: - DenominationTarget
+
+    func testDenominationTargetDefaults() {
+        XCTAssertEqual(CashuSwift.DenominationTarget.default.countPerDenomination, 3)
+        XCTAssertNil(CashuSwift.DenominationTarget.default.maxDenomination)
+    }
+
+    func testDenominationTargetClampsNegativeCount() {
+        XCTAssertEqual(CashuSwift.DenominationTarget(countPerDenomination: -4).countPerDenomination, 0)
+    }
+
+    func testExplicitMaxDenominationCapsTarget() {
+        let t = CashuSwift.DenominationTarget(countPerDenomination: 3, maxDenomination: 8)
+        let dist = CashuSwift.idealDistribution(balance: 10_000, target: t, keyset: fullKeyset)
+        XCTAssertEqual(sum(dist), 10_000)
+        XCTAssertTrue(dist.allSatisfy { $0 <= 8 }, "explicit cap must bound denominations")
+    }
+}

--- a/Tests/cashu-swiftTests/OfflineDistributionHooksTests.swift
+++ b/Tests/cashu-swiftTests/OfflineDistributionHooksTests.swift
@@ -1,0 +1,162 @@
+//
+//  OfflineDistributionHooksTests.swift
+//  CashuSwiftTests
+//
+//  Tests for the offline-optimization `preferredDistribution` hooks threaded
+//  through send / receive / swap (M3):
+//    * network-free validation guards (always run), and
+//    * end-to-end application of a supplied distribution against the public
+//      FakeWallet mint (skipped when unreachable).
+//
+
+import XCTest
+@testable import CashuSwift
+import BIP39
+
+private func keyset(_ id: String = "00aa", ppk: Int = 0,
+                    denominations: [Int] = (0...12).map { 1 << $0 }) -> CashuSwift.Keyset {
+    let keysJSON = denominations.map { "\"\($0)\":\"02aa\"" }.joined(separator: ",")
+    let json = """
+    {"id":"\(id)","unit":"sat","active":true,"input_fee_ppk":\(ppk),"keys":{\(keysJSON)}}
+    """
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+private func syntheticProofs(_ amounts: [Int], keysetID: String = "00aa") -> [CashuSwift.Proof] {
+    amounts.enumerated().map {
+        CashuSwift.Proof(keysetID: keysetID, amount: $0.element,
+                         secret: "s\($0.offset)", C: "C\($0.offset)", dleq: nil)
+    }
+}
+
+final class OfflineDistributionHooksTests: XCTestCase {
+
+    // MARK: - Network-free validation guards
+
+    /// A `preferredKeepDistribution` that doesn't sum to the keep amount is rejected
+    /// before any mint round-trip.
+    func testSendRejectsMismatchedKeepDistribution() async throws {
+        let mint = CashuSwift.Mint(url: URL(string: "https://unused.test")!, keysets: [keyset()])
+        let inputs = syntheticProofs([8, 8])     // sum 16
+        do {
+            // amount 10, fee 0 ⇒ keep 6; supply a distribution summing to 5.
+            _ = try await CashuSwift.send(inputs: inputs, mint: mint, amount: 10, seed: nil,
+                                          preferredKeepDistribution: [1, 4])
+            XCTFail("expected preferredDistributionMismatch")
+        } catch CashuError.preferredDistributionMismatch {
+            // expected — thrown at the guard, before generateOutputs / network
+        }
+    }
+
+    /// The mismatch guard fires regardless of how wrong the sum is, and a correct
+    /// sum passes the guard (it then proceeds toward the network, which we don't
+    /// reach here — so we only assert the guard itself does not throw a mismatch).
+    func testSendKeepDistributionGuardBoundary() async throws {
+        let mint = CashuSwift.Mint(url: URL(string: "https://unused.test")!, keysets: [keyset()])
+        let inputs = syntheticProofs([8, 8])     // sum 16, amount 10, fee 0 ⇒ keep 6
+        // Oversized distribution is also rejected.
+        do {
+            _ = try await CashuSwift.send(inputs: inputs, mint: mint, amount: 10, seed: nil,
+                                          preferredKeepDistribution: [2, 4, 2])  // sums 8 ≠ 6
+            XCTFail("expected preferredDistributionMismatch")
+        } catch CashuError.preferredDistributionMismatch { }
+    }
+
+    // MARK: - End-to-end (FakeWallet mint)
+
+    private let mintURL = TestEndpoints.fakeSuccess
+
+    /// `send` applies the supplied keep distribution to the change proofs while the
+    /// token (send) proofs stay a base-2 split of the sent amount.
+    func testSendAppliesPreferredKeepDistribution() async throws {
+        let (mint, seeded) = try await MintTestSupport.seedProofsAtFakeMint(mintURL, amount: 16)
+        let sendAmount = 3
+        let fee = try CashuSwift.calculateFee(for: seeded, of: mint)
+        let keepAmount = seeded.sum - sendAmount - fee
+        let preferredKeep = Array(repeating: 1, count: keepAmount)   // distinct from base-2
+
+        let result = try await CashuSwift.send(inputs: seeded, mint: mint, amount: sendAmount,
+                                               seed: nil, preferredKeepDistribution: preferredKeep)
+
+        XCTAssertEqual(result.send.sum, sendAmount)
+        XCTAssertEqual(result.change.map(\.amount).sorted(), preferredKeep.sorted(),
+                       "change proofs should follow the preferred keep distribution")
+        XCTAssertEqual(result.change.count, keepAmount, "all change proofs are 1-sat")
+    }
+
+    /// `receive` applies the supplied return distribution to the received proofs.
+    func testReceiveAppliesPreferredReturnDistribution() async throws {
+        let (mint, seeded) = try await MintTestSupport.seedProofsAtFakeMint(mintURL, amount: 16)
+        let token = CashuSwift.Token(proofs: [mint.url.absoluteString: seeded.withShortKeysetID()],
+                                     unit: "sat", memo: nil)
+        let fee = try CashuSwift.calculateFee(for: seeded, of: mint)
+        let net = seeded.sum - fee
+        let preferred = Array(repeating: 1, count: net)
+
+        let result = try await CashuSwift.receive(token: token, of: mint, seed: nil,
+                                                  privateKey: nil,
+                                                  preferredReturnDistribution: preferred)
+
+        XCTAssertEqual(result.proofs.sum, net)
+        XCTAssertEqual(result.proofs.map(\.amount).sorted(), preferred.sorted())
+    }
+
+    /// `swap` with `amount: nil` shapes the *entire* returned pool — the whole-pool
+    /// adjustment that enables receive- and consolidation-time rebalancing.
+    func testSwapWholePoolAppliesPreferredDistribution() async throws {
+        let (mint, seeded) = try await MintTestSupport.seedProofsAtFakeMint(mintURL, amount: 32)
+        let fee = try CashuSwift.calculateFee(for: seeded, of: mint)
+        let net = seeded.sum - fee
+        let preferred = Array(repeating: 1, count: net)   // all 1-sat (distinct from base-2)
+
+        let result = try await CashuSwift.swap(inputs: seeded, with: mint, amount: nil, seed: nil,
+                                               preferredReturnDistribution: preferred)
+
+        XCTAssertTrue(result.change.isEmpty, "whole-pool keep ⇒ no change bucket")
+        XCTAssertEqual(result.new.sum, net)
+        XCTAssertEqual(result.new.map(\.amount).sorted(), preferred.sorted())
+    }
+
+    /// Regression: `swap(amount: nil)` with no preferred distribution still returns a
+    /// plain base-2 split (the common receive path is unchanged by the restructure).
+    func testSwapWholePoolNilPreferredIsBase2() async throws {
+        let (mint, seeded) = try await MintTestSupport.seedProofsAtFakeMint(mintURL, amount: 21)
+        let fee = try CashuSwift.calculateFee(for: seeded, of: mint)
+        let net = seeded.sum - fee
+
+        let result = try await CashuSwift.swap(inputs: seeded, with: mint, amount: nil, seed: nil)
+
+        XCTAssertEqual(result.new.sum, net)
+        XCTAssertEqual(result.new.map(\.amount).sorted(),
+                       CashuSwift.splitIntoBase2Numbers(net).sorted())
+    }
+
+    /// End-to-end consolidation: swapping the whole balance to `idealDistribution`
+    /// lands the wallet exactly on its target shape (zero gap).
+    func testConsolidationSwapReachesIdealShape() async throws {
+        let (mint, seeded) = try await MintTestSupport.seedProofsAtFakeMint(mintURL, amount: 100)
+        let fee = try CashuSwift.calculateFee(for: seeded, of: mint)
+        let net = seeded.sum - fee
+        guard let activeKeyset = CashuSwift.activeKeysetForUnit("sat", mint: mint) else {
+            XCTFail("fake mint should have an active sat keyset"); return
+        }
+        let ideal = CashuSwift.idealDistribution(balance: net, keyset: activeKeyset)
+
+        let result = try await CashuSwift.swap(inputs: seeded, with: mint, amount: nil, seed: nil,
+                                               preferredReturnDistribution: ideal)
+
+        XCTAssertEqual(result.new.map(\.amount).sorted(), ideal.sorted())
+        let gap = CashuSwift.denominationGap(for: result.new, keyset: activeKeyset)
+        XCTAssertEqual(gap.distance, 0, "consolidated wallet should sit exactly on target")
+    }
+
+    /// The mismatch guard also fires on the real swap path (with valid input DLEQ).
+    func testSwapWholePoolRejectsMismatchedDistribution() async throws {
+        let (mint, seeded) = try await MintTestSupport.seedProofsAtFakeMint(mintURL, amount: 16)
+        do {
+            _ = try await CashuSwift.swap(inputs: seeded, with: mint, amount: nil, seed: nil,
+                                          preferredReturnDistribution: [1, 2, 4])  // ≠ 16 − fee
+            XCTFail("expected preferredDistributionMismatch")
+        } catch CashuError.preferredDistributionMismatch { }
+    }
+}

--- a/Tests/cashu-swiftTests/OfflineTokenTests.swift
+++ b/Tests/cashu-swiftTests/OfflineTokenTests.swift
@@ -1,0 +1,115 @@
+//
+//  OfflineTokenTests.swift
+//  CashuSwiftTests
+//
+//  Tests for the offline-send primitive: the synchronous, network-free
+//  `offlineToken(for:mint:memo:)` builder and the `canSendOffline` predicate,
+//  plus their round-trip with `selectProofs(…, purpose: .tokenTransferUnlocked)`.
+//
+
+import XCTest
+@testable import CashuSwift
+
+private func keyset(_ id: String = "00aa", unit: String = "sat",
+                    denominations: [Int] = (0...10).map { 1 << $0 }) -> CashuSwift.Keyset {
+    let keysJSON = denominations.map { "\"\($0)\":\"02aa\"" }.joined(separator: ",")
+    let json = """
+    {"id":"\(id)","unit":"\(unit)","active":true,"input_fee_ppk":0,"keys":{\(keysJSON)}}
+    """
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+private let lockedSecret = "[\"P2PK\",{\"nonce\":\"abc123\",\"data\":\"02deadbeef\",\"tags\":null}]"
+
+private func proof(_ amount: Int, _ keysetID: String = "00aa", id: Int, locked: Bool = false) -> CashuSwift.Proof {
+    CashuSwift.Proof(keysetID: keysetID, amount: amount,
+                     secret: locked ? lockedSecret : "secret-\(id)", C: "C-\(id)", dleq: nil)
+}
+
+private func proofs(_ amounts: [Int], keysetID: String = "00aa") -> [CashuSwift.Proof] {
+    amounts.enumerated().map { proof($0.element, keysetID, id: $0.offset) }
+}
+
+final class OfflineTokenTests: XCTestCase {
+
+    private let m = CashuSwift.Mint(url: URL(string: "https://test.mint")!, keysets: [keyset()])
+
+    // MARK: - offlineToken
+
+    func testOfflineTokenBundlesProofs() throws {
+        let token = try CashuSwift.offlineToken(for: proofs([1, 2]), mint: m, memo: "here you go")
+        XCTAssertEqual(token.unit, "sat")
+        XCTAssertEqual(token.memo, "here you go")
+        XCTAssertEqual(token.proofsByMint.count, 1)
+        XCTAssertEqual(token.proofsByMint[m.url.absoluteString]?.sum, 3)
+    }
+
+    /// The build is genuinely network-free: it succeeds even for a mint URL that
+    /// could never be contacted (it is a synchronous, non-`async` call).
+    func testOfflineTokenIsNetworkFree() throws {
+        let offlineMint = CashuSwift.Mint(url: URL(string: "https://192.0.2.1.invalid")!,
+                                          keysets: [keyset()])
+        let token = try CashuSwift.offlineToken(for: proofs([4, 8]), mint: offlineMint)
+        XCTAssertEqual(token.proofsByMint.values.first?.sum, 12)
+    }
+
+    func testOfflineTokenRejectsEmptyProofs() {
+        XCTAssertThrowsError(try CashuSwift.offlineToken(for: [], mint: m))
+    }
+
+    func testOfflineTokenRejectsLockedProofs() {
+        let withLock = proofs([1, 2]) + [proof(4, id: 99, locked: true)]
+        XCTAssertThrowsError(try CashuSwift.offlineToken(for: withLock, mint: m)) { error in
+            guard case CashuError.spendingConditionError = error else {
+                return XCTFail("expected spendingConditionError, got \(error)")
+            }
+        }
+    }
+
+    func testOfflineTokenRejectsMixedUnits() {
+        let multiMint = CashuSwift.Mint(url: URL(string: "https://test.mint")!,
+                                        keysets: [keyset("00aa", unit: "sat"),
+                                                  keyset("00bb", unit: "usd")])
+        let mixed = proofs([1, 2], keysetID: "00aa") + proofs([4], keysetID: "00bb")
+        XCTAssertThrowsError(try CashuSwift.offlineToken(for: mixed, mint: multiMint))
+    }
+
+    // MARK: - Round-trip with selectProofs
+
+    /// A `.directToken` selection feeds straight into `offlineToken` — the full
+    /// offline-send path, no network anywhere.
+    func testSelectProofsDirectTokenRoundTrip() throws {
+        let wallet = proofs([1, 2, 4, 8])
+        let r = try CashuSwift.selectProofs(wallet, targetAmount: 3, mint: m, unit: "sat",
+                                            purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .directToken)
+        let token = try CashuSwift.offlineToken(for: r.selected, mint: m, memo: nil)
+        XCTAssertEqual(token.proofsByMint[m.url.absoluteString]?.sum, 3)
+    }
+
+    // MARK: - canSendOffline
+
+    func testCanSendOfflineTrueForExactSubsets() {
+        let wallet = proofs([1, 2, 4])
+        for amount in [1, 2, 3, 4, 5, 6, 7] {   // every value in [1, 7] is exactly representable
+            XCTAssertTrue(CashuSwift.canSendOffline(wallet, amount: amount, mint: m, unit: "sat"),
+                          "\(amount) should be offline-sendable")
+        }
+    }
+
+    func testCanSendOfflineFalseWhenChangeWouldBeNeeded() {
+        // {2,4}: amounts 2,4,6 only — 3 and 5 require change (a mint swap).
+        let wallet = proofs([2, 4])
+        XCTAssertFalse(CashuSwift.canSendOffline(wallet, amount: 3, mint: m, unit: "sat"))
+        XCTAssertFalse(CashuSwift.canSendOffline(wallet, amount: 5, mint: m, unit: "sat"))
+        XCTAssertTrue(CashuSwift.canSendOffline(wallet, amount: 6, mint: m, unit: "sat"))
+    }
+
+    func testCanSendOfflineFalseWhenInsufficient() {
+        XCTAssertFalse(CashuSwift.canSendOffline(proofs([1, 2]), amount: 10, mint: m, unit: "sat"))
+    }
+
+    func testCanSendOfflineFalseForEmptyWallet() {
+        XCTAssertFalse(CashuSwift.canSendOffline([CashuSwift.Proof](), amount: 1, mint: m, unit: "sat"))
+    }
+}

--- a/Tests/cashu-swiftTests/ProofSelectionTargetTests.swift
+++ b/Tests/cashu-swiftTests/ProofSelectionTargetTests.swift
@@ -62,7 +62,7 @@ final class ProofSelectionTargetTests: XCTestCase {
         let r = try CashuSwift.selectProofs(proofs([512, 512]), targetAmount: 500, mint: m,
                                             unit: "sat", purpose: .swap,
                                             denominationTarget: .default)
-        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertEqual(r.kind, .swap)
         XCTAssertEqual(r.inputFee, 0)
         XCTAssertEqual(r.selected.count, 1)            // one 512 covers it
         XCTAssertEqual(r.changeAmount, 12)

--- a/Tests/cashu-swiftTests/ProofSelectionTargetTests.swift
+++ b/Tests/cashu-swiftTests/ProofSelectionTargetTests.swift
@@ -1,0 +1,191 @@
+//
+//  ProofSelectionTargetTests.swift
+//  CashuSwiftTests
+//
+//  Tests for the optional `denominationTarget` on `selectProofs`: it shapes the
+//  change outputs toward the wallet's ideal denomination distribution (deficit
+//  fill) while leaving input selection — and therefore fee/change/count — exactly
+//  as the no-target path produces it.
+//
+
+import XCTest
+@testable import CashuSwift
+
+// MARK: - Fixtures
+
+private let allDenoms = (0...20).map { 1 << $0 }   // 1 … 1,048,576
+
+private func ks(_ id: String = "00aa", ppk: Int = 0, active: Bool = true,
+                unit: String = "sat", denominations: [Int] = allDenoms) -> CashuSwift.Keyset {
+    let keysJSON = denominations.map { "\"\($0)\":\"02aa\"" }.joined(separator: ",")
+    let json = """
+    {"id":"\(id)","unit":"\(unit)","active":\(active),"input_fee_ppk":\(ppk),"keys":{\(keysJSON)}}
+    """
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+private func mint(_ keysets: [CashuSwift.Keyset] = [ks()]) -> CashuSwift.Mint {
+    CashuSwift.Mint(url: URL(string: "https://test.mint")!, keysets: keysets)
+}
+
+private func proofs(_ amounts: [Int], keysetID: String = "00aa") -> [CashuSwift.Proof] {
+    amounts.enumerated().map {
+        CashuSwift.Proof(keysetID: keysetID, amount: $0.element,
+                         secret: "s\($0.offset)", C: "C\($0.offset)", dleq: nil)
+    }
+}
+
+private func sum(_ xs: [Int]) -> Int { xs.reduce(0, +) }
+private func isPowerOfTwo(_ n: Int) -> Bool { n > 0 && (n & (n - 1)) == 0 }
+
+private struct SeededRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+final class ProofSelectionTargetTests: XCTestCase {
+
+    private let m = mint()
+
+    // MARK: - Target-aware change outputs
+
+    /// A wallet of only large coins, swapping with change, rebuilds its depleted
+    /// small denominations in the change instead of taking a base-2 split.
+    func testTargetAwareChangeFillsSmallDenominationDeficits() throws {
+        let r = try CashuSwift.selectProofs(proofs([512, 512]), targetAmount: 500, mint: m,
+                                            unit: "sat", purpose: .swap,
+                                            denominationTarget: .default)
+        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.count, 1)            // one 512 covers it
+        XCTAssertEqual(r.changeAmount, 12)
+        // Target-aware: fill the denom-1 and denom-2 deficits rather than base-2 [4,8].
+        XCTAssertEqual(r.changeOutputAmounts, [1, 1, 1, 1, 2, 2, 2, 2])
+        XCTAssertNotEqual(r.changeOutputAmounts, CashuSwift.splitIntoBase2Numbers(12))
+        XCTAssertEqual(sum(r.changeOutputAmounts), r.changeAmount)
+    }
+
+    /// Send (payment) outputs always stay base-2 — their denominations are the
+    /// recipient's concern, not ours.
+    func testSendOutputsStayBase2EvenWithTarget() throws {
+        let r = try CashuSwift.selectProofs(proofs([512, 512]), targetAmount: 500, mint: m,
+                                            unit: "sat", purpose: .swap,
+                                            denominationTarget: .default)
+        XCTAssertEqual(r.sendOutputAmounts, CashuSwift.splitIntoBase2Numbers(500))
+    }
+
+    /// Without a target, change is the plain base-2 split (regression guard).
+    func testNilTargetChangeIsBase2() throws {
+        let r = try CashuSwift.selectProofs(proofs([512, 512]), targetAmount: 500, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.changeAmount, 12)
+        XCTAssertEqual(r.changeOutputAmounts, CashuSwift.splitIntoBase2Numbers(12)) // [4, 8]
+    }
+
+    /// A direct (exact) send is unaffected by the target: still a direct token, no
+    /// change, no outputs, identical inputs.
+    func testDirectExactSendUnaffectedByTarget() throws {
+        let input = proofs([1, 2, 4])
+        let withTarget = try CashuSwift.selectProofs(input, targetAmount: 3, mint: m, unit: "sat",
+                                                     purpose: .tokenTransferUnlocked,
+                                                     denominationTarget: .default)
+        let without = try CashuSwift.selectProofs(input, targetAmount: 3, mint: m, unit: "sat",
+                                                  purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(withTarget.kind, .directToken)
+        XCTAssertEqual(withTarget.changeOutputAmounts, [])
+        XCTAssertEqual(withTarget.sendOutputAmounts, [])
+        XCTAssertEqual(withTarget.selected.map(\.amount), without.selected.map(\.amount))
+        XCTAssertEqual(withTarget.selected.map(\.secret), without.selected.map(\.secret))
+    }
+
+    // MARK: - Invariants (property)
+
+    /// The shaped change always sums to exactly the change amount and uses only
+    /// power-of-two denominations — so it can feed `preferredReturnDistribution`
+    /// without a `preferredDistributionMismatch`.
+    func testChangeOutputAmountsAlwaysSumToChangeAmount_random() throws {
+        var rng = SeededRNG(seed: 0xC0FFEE)
+        var sawChange = false
+        for _ in 0..<1500 {
+            let wallet = (0..<(Int(rng.next() % 8) + 1)).map { _ in 1 << Int(rng.next() % 11) }
+            let total = sum(wallet)
+            let target = Int(rng.next() % UInt64(max(1, total)))   // < total ⇒ feasible
+            guard target > 0 else { continue }
+            let r = try CashuSwift.selectProofs(proofs(wallet), targetAmount: target, mint: m,
+                                                unit: "sat", purpose: .swap,
+                                                denominationTarget: .default)
+            XCTAssertEqual(sum(r.changeOutputAmounts), r.changeAmount)
+            XCTAssertTrue(r.changeOutputAmounts.allSatisfy(isPowerOfTwo))
+            if r.changeAmount > 0 { sawChange = true }
+        }
+        XCTAssertTrue(sawChange, "test should have exercised the change path")
+    }
+
+    /// The crux regression: supplying a target must NOT change which proofs are
+    /// selected, the fee, the change amount, or the send outputs — only the change
+    /// output denominations. Input selection optimality is fully preserved.
+    func testTargetDoesNotAlterInputSelection_random() throws {
+        var rng = SeededRNG(seed: 0x5151)
+        for _ in 0..<1500 {
+            let wallet = (0..<(Int(rng.next() % 10) + 1)).map { _ in 1 << Int(rng.next() % 12) }
+            let total = sum(wallet)
+            let target = Int(rng.next() % UInt64(max(1, total)))
+            guard target > 0 else { continue }
+            for purpose in [CashuSwift.ProofSelectionPurpose.swap, .tokenTransferUnlocked] {
+                let a = try CashuSwift.selectProofs(proofs(wallet), targetAmount: target, mint: m,
+                                                    unit: "sat", purpose: purpose)
+                let b = try CashuSwift.selectProofs(proofs(wallet), targetAmount: target, mint: m,
+                                                    unit: "sat", purpose: purpose,
+                                                    denominationTarget: .default)
+                XCTAssertEqual(a.kind, b.kind)
+                XCTAssertEqual(a.selected.map(\.secret), b.selected.map(\.secret))
+                XCTAssertEqual(a.inputFee, b.inputFee)
+                XCTAssertEqual(a.changeAmount, b.changeAmount)
+                XCTAssertEqual(a.netAmount, b.netAmount)
+                XCTAssertEqual(a.sendOutputAmounts, b.sendOutputAmounts)
+            }
+        }
+    }
+
+    // MARK: - Value demonstration
+
+    /// The shaped change leaves the wallet closer to its ideal shape than a base-2
+    /// change would, when small denominations are depleted.
+    func testTargetAwareChangeReducesGapVersusBase2() throws {
+        let keyset = ks()
+        let r = try CashuSwift.selectProofs(proofs([512, 512, 512, 512]), targetAmount: 503,
+                                            mint: m, unit: "sat", purpose: .swap,
+                                            denominationTarget: .default)
+        XCTAssertEqual(r.changeAmount, 9)
+        let retainedAfterSpend = proofs(Array(repeating: 512, count: 3))   // 3 unselected 512s
+
+        let gapTarget = CashuSwift.denominationGap(
+            for: retainedAfterSpend + proofs(r.changeOutputAmounts), keyset: keyset).distance
+        let gapBase2 = CashuSwift.denominationGap(
+            for: retainedAfterSpend + proofs(CashuSwift.splitIntoBase2Numbers(9)), keyset: keyset).distance
+
+        XCTAssertTrue(r.changeOutputAmounts.contains(1), "should rebuild small denominations")
+        XCTAssertLessThan(gapTarget, gapBase2)
+    }
+
+    // MARK: - Degenerate
+
+    /// With fees on the keyset, the target still only shapes change; the fee-bearing
+    /// selection is unchanged and the change still sums correctly.
+    func testTargetWithFeesKeepsChangeExact() throws {
+        let feeMint = mint([ks("00bb", ppk: 100)])
+        let r = try CashuSwift.selectProofs(proofs([64, 64, 64], keysetID: "00bb"),
+                                            targetAmount: 100, mint: feeMint, unit: "sat",
+                                            purpose: .swap, denominationTarget: .default)
+        XCTAssertGreaterThan(r.inputFee, 0)
+        XCTAssertEqual(sum(r.changeOutputAmounts), r.changeAmount)
+        XCTAssertEqual(r.netAmount, sum(r.selected.map(\.amount)) - r.inputFee)
+    }
+}

--- a/Tests/cashu-swiftTests/ProofSelectionTests.swift
+++ b/Tests/cashu-swiftTests/ProofSelectionTests.swift
@@ -1,0 +1,444 @@
+//
+//  ProofSelectionTests.swift
+//  CashuSwiftTests
+//
+//  Pure unit tests for the fee-aware proof selector — no network. Covers the
+//  documented unit cases, determinism, the generic "select in place" boundary,
+//  binary-bundling round-trips, and brute-force property tests that compare the
+//  dynamic program against exhaustive subset enumeration for small wallets.
+//
+
+import XCTest
+@testable import CashuSwift
+
+// MARK: - Test fixtures
+
+/// Builds a `Keyset` with the given fee rate / activity by decoding minimal JSON
+/// (the model has a custom `Decodable` init and no memberwise initializer).
+private func ks(_ id: String, ppk: Int, active: Bool = true, unit: String = "sat") -> CashuSwift.Keyset {
+    let json = "{\"id\":\"\(id)\",\"unit\":\"\(unit)\",\"active\":\(active),\"input_fee_ppk\":\(ppk)}"
+    return try! JSONDecoder().decode(CashuSwift.Keyset.self, from: Data(json.utf8))
+}
+
+private func mint(_ keysets: [CashuSwift.Keyset]) -> CashuSwift.Mint {
+    CashuSwift.Mint(url: URL(string: "https://test.mint")!, keysets: keysets)
+}
+
+/// A valid serialized P2PK spending condition — makes a proof "locked".
+private let lockedSecret = "[\"P2PK\",{\"nonce\":\"abc123\",\"data\":\"02deadbeef\",\"tags\":null}]"
+
+private func proof(_ amount: Int, _ keysetID: String, id: Int, locked: Bool = false) -> CashuSwift.Proof {
+    CashuSwift.Proof(keysetID: keysetID,
+                     amount: amount,
+                     secret: locked ? lockedSecret : "secret-\(id)",
+                     C: "C-\(id)-\(keysetID)",
+                     dleq: nil)
+}
+
+/// A wallet-side proof type distinct from `CashuSwift.Proof`, used to prove the
+/// generic "select in place" boundary returns the caller's own type.
+private struct WalletProof: ProofRepresenting {
+    let keysetID: String
+    let C: String
+    let secret: String
+    let amount: Int
+    let dleq: CashuSwift.DLEQ?
+}
+
+// MARK: - Deterministic RNG (SplitMix64) for property tests
+
+private struct SeededRNG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+// MARK: - Brute-force oracles
+
+private func ceilFee(_ ppk: Int) -> Int { ppk <= 0 ? 0 : (ppk + 999) / 1000 }
+
+/// Optimal `(fee, change, count, raw)` over all subsets with `net >= target`,
+/// minimised lexicographically. `nil` if no subset is feasible.
+private func bruteForceMint(_ proofs: [(amount: Int, ppk: Int)], target: Int)
+-> (fee: Int, change: Int, count: Int, raw: Int)? {
+    var best: (fee: Int, change: Int, count: Int, raw: Int)?
+    for mask in 0 ..< (1 << proofs.count) {
+        var raw = 0, ppk = 0, count = 0
+        for i in proofs.indices where mask & (1 << i) != 0 {
+            raw += proofs[i].amount; ppk += proofs[i].ppk; count += 1
+        }
+        let fee = ceilFee(ppk)
+        let net = raw - fee
+        guard net >= target else { continue }
+        let cand = (fee: fee, change: net - target, count: count, raw: raw)
+        if best == nil
+            || (cand.fee, cand.change, cand.count, cand.raw)
+             < (best!.fee, best!.change, best!.count, best!.raw) {
+            best = cand
+        }
+    }
+    return best
+}
+
+/// Optimal `(count, ppk)` over subsets summing *exactly* to `target`.
+private func bruteForceExact(_ proofs: [(amount: Int, ppk: Int)], target: Int)
+-> (count: Int, ppk: Int)? {
+    var best: (count: Int, ppk: Int)?
+    for mask in 0 ..< (1 << proofs.count) {
+        var raw = 0, ppk = 0, count = 0
+        for i in proofs.indices where mask & (1 << i) != 0 {
+            raw += proofs[i].amount; ppk += proofs[i].ppk; count += 1
+        }
+        guard raw == target else { continue }
+        if best == nil || (count, ppk) < (best!.count, best!.ppk) { best = (count, ppk) }
+    }
+    return best
+}
+
+final class ProofSelectionTests: XCTestCase {
+
+    // MARK: Documented unit cases
+
+    /// #1 — exact direct send pays no fee.
+    func testDirectExactPaysNoFee() throws {
+        let m = mint([ks("A", ppk: 100)])
+        let proofs = [proof(1, "A", id: 1), proof(2, "A", id: 2), proof(4, "A", id: 3)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 3, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .directToken)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.reduce(0) { $0 + $1.amount }, 3)
+        XCTAssertEqual(r.selected.count, 2)
+        XCTAssertEqual(r.changeAmount, 0)
+    }
+
+    /// #2 — direct exact beats the swap path even with high keyset fees.
+    func testDirectExactBeatsHighFeeSwap() throws {
+        let m = mint([ks("A", ppk: 999)])
+        let proofs = [proof(10, "A", id: 1)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 10, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .directToken)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.count, 1)
+    }
+
+    /// #3 — fee-aware: raw amount is not enough once the fee is subtracted.
+    func testFeeAwareRawAmountNotEnough() {
+        let m = mint([ks("A", ppk: 1000)])
+        let proofs = [proof(100, "A", id: 1)]
+        XCTAssertThrowsError(try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                                         unit: "sat", purpose: .swap)) { error in
+            guard case CashuSwift.ProofSelectionError.insufficientFunds(let raw, let target, _) = error else {
+                return XCTFail("Expected insufficientFunds, got \(error)")
+            }
+            XCTAssertEqual(raw, 100)
+            XCTAssertEqual(target, 100)
+        }
+    }
+
+    /// #4 — fee-aware chooses the lower-fee feasible subset.
+    func testFeeAwareChoosesLowerFee() throws {
+        let m = mint([ks("HI", ppk: 1000), ks("LO", ppk: 0)])
+        let proofs = [proof(100, "HI", id: 1), proof(101, "LO", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.selected.first?.amount, 101)
+        XCTAssertEqual(r.netAmount, 101)
+        XCTAssertEqual(r.changeAmount, 1)
+    }
+
+    /// #5 — rounding boundary: ppk 500 + 500 + 0 rounds up to fee 1.
+    func testFeeRoundingBoundary() throws {
+        let m = mint([ks("F", ppk: 500), ks("Z", ppk: 0)])
+        let proofs = [proof(5, "F", id: 1), proof(5, "F", id: 2), proof(1, "Z", id: 3)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 10, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 3)
+        XCTAssertEqual(r.selected.reduce(0) { $0 + $1.amount }, 11)
+        XCTAssertEqual(r.inputFee, 1)
+        XCTAssertEqual(r.netAmount, 10)
+        XCTAssertEqual(r.changeAmount, 0)
+    }
+
+    /// #6 — fees are computed only from the selected proofs' keysets.
+    func testMultipleKeysetFees() throws {
+        let m = mint([ks("A", ppk: 0), ks("B", ppk: 999)])
+        // Two ways to reach net 8: {8@A} fee 0, or {8@B} fee 1. Lower fee wins.
+        let proofs = [proof(8, "A", id: 1), proof(8, "B", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 8, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.inputFee, 0)
+        XCTAssertEqual(r.selected.first?.keysetID, "A")
+    }
+
+    /// #7 — for mint transactions, inactive keysets win an otherwise-exact tie.
+    func testInactiveKeysetPreferredForMint() throws {
+        let m = mint([ks("ACT", ppk: 0, active: true), ks("INACT", ppk: 0, active: false)])
+        let proofs = [proof(100, "ACT", id: 1), proof(100, "INACT", id: 2)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.preferInactiveKeysetsForMintTransactions = true
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.selected.first?.keysetID, "INACT")
+    }
+
+    /// #8 — for direct sends, active keysets win an otherwise-exact tie.
+    func testActiveKeysetPreferredForDirectSend() throws {
+        let m = mint([ks("ACT", ppk: 0, active: true), ks("INACT", ppk: 0, active: false)])
+        let proofs = [proof(100, "ACT", id: 1), proof(100, "INACT", id: 2)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.avoidInactiveKeysetsForDirectSend = true
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked, policy: policy)
+        XCTAssertEqual(r.kind, .directToken)
+        XCTAssertEqual(r.selected.first?.keysetID, "ACT")
+    }
+
+    /// #9 — locked proofs are filtered out (not spendable inputs in v1).
+    func testLockedProofsFiltered() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(100, "A", id: 1, locked: true), proof(100, "A", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertFalse(r.selected.contains { $0.secret == lockedSecret })
+
+        // Only a locked proof present ⇒ nothing eligible.
+        XCTAssertThrowsError(try CashuSwift.selectProofs([proof(100, "A", id: 3, locked: true)],
+                                                         targetAmount: 50, mint: m,
+                                                         unit: "sat", purpose: .swap)) { error in
+            guard case CashuSwift.ProofSelectionError.noEligibleProofs = error else {
+                return XCTFail("Expected noEligibleProofs, got \(error)")
+            }
+        }
+    }
+
+    /// #10 — state-limit behaviour is explicit: throw vs. best-effort.
+    func testStateLimitThrows() {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(40, "A", id: 1), proof(40, "A", id: 2), proof(40, "A", id: 3)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.maxStates = 1
+        policy.bestEffortWhenStateLimitHit = false
+        XCTAssertThrowsError(try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                                         unit: "sat", purpose: .swap, policy: policy)) { error in
+            guard case CashuSwift.ProofSelectionError.stateLimitExceeded = error else {
+                return XCTFail("Expected stateLimitExceeded, got \(error)")
+            }
+        }
+    }
+
+    func testStateLimitBestEffort() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(40, "A", id: 1), proof(40, "A", id: 2), proof(40, "A", id: 3)]
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.maxStates = 1
+        policy.bestEffortWhenStateLimitHit = true
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        XCTAssertEqual(r.optimality, .bestEffortStateLimitHit)
+        XCTAssertGreaterThanOrEqual(r.netAmount, 100)
+    }
+
+    // MARK: Keyset resolution & diagnostics
+
+    func testMissingKeysetThrows() {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(100, "UNKNOWN", id: 1)]
+        XCTAssertThrowsError(try CashuSwift.selectProofs(proofs, targetAmount: 50, mint: m,
+                                                         unit: "sat", purpose: .swap)) { error in
+            guard case CashuSwift.ProofSelectionError.missingKeysetInformation(let id) = error else {
+                return XCTFail("Expected missingKeysetInformation, got \(error)")
+            }
+            XCTAssertEqual(id, "UNKNOWN")
+        }
+    }
+
+    func testWrongUnitFilteredNotThrown() throws {
+        let m = mint([ks("SAT", ppk: 0, unit: "sat"), ks("USD", ppk: 0, unit: "usd")])
+        let proofs = [proof(100, "SAT", id: 1), proof(100, "USD", id: 2)]
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.selected.first?.keysetID, "SAT")
+    }
+
+    func testShortV1KeysetIDResolves() throws {
+        let full = "01" + String(repeating: "a", count: 62)   // 64 chars
+        let m = mint([ks(full, ppk: 0)])
+        let shortID = String(full.prefix(16))
+        let proofs = [proof(100, shortID, id: 1)]   // proof carries shortened id
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 1)
+        XCTAssertEqual(r.keysetIDsSpent, [shortID])
+    }
+
+    // MARK: Determinism & the generic boundary
+
+    func testDeterministicForSameRequest() throws {
+        let m = mint([ks("A", ppk: 1), ks("B", ppk: 2, active: false)])
+        let proofs = (0..<12).map { proof([1, 2, 4, 8][$0 % 4], $0 % 2 == 0 ? "A" : "B", id: $0) }
+        let seed = Data([1, 2, 3, 4])
+        var policy = CashuSwift.ProofSelectionPolicy.default
+        policy.randomSeed = seed
+        let a = try CashuSwift.selectProofs(proofs, targetAmount: 13, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        let b = try CashuSwift.selectProofs(proofs, targetAmount: 13, mint: m,
+                                            unit: "sat", purpose: .swap, policy: policy)
+        XCTAssertEqual(a.selected.map { $0.C }, b.selected.map { $0.C })
+    }
+
+    /// The "select in place" guarantee: a foreign `ProofRepresenting` type goes
+    /// in, the *same* type comes back — no conversion, no downcast.
+    func testSelectInPlaceReturnsCallerType() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let wallet = [
+            WalletProof(keysetID: "A", C: "wc1", secret: "s1", amount: 4, dleq: nil),
+            WalletProof(keysetID: "A", C: "wc2", secret: "s2", amount: 8, dleq: nil),
+            WalletProof(keysetID: "A", C: "wc3", secret: "s3", amount: 16, dleq: nil),
+        ]
+        let result = try CashuSwift.selectProofs(wallet, targetAmount: 12, mint: m,
+                                                 unit: "sat", purpose: .tokenTransferUnlocked)
+        // Compile-time proof of type preservation:
+        let selected: [WalletProof] = result.selected
+        XCTAssertEqual(selected.reduce(0) { $0 + $1.amount }, 12)
+        // Identity preserved: every returned proof is one of the inputs (by C).
+        let inputCs = Set(wallet.map { $0.C })
+        XCTAssertTrue(selected.allSatisfy { inputCs.contains($0.C) })
+    }
+
+    // MARK: Binary bundling round-trip
+
+    func testBundlingExpandsToDistinctInputProofs() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = (0..<13).map { proof(1, "A", id: $0) }   // 13 identical-shape proofs
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 5, mint: m,
+                                            unit: "sat", purpose: .swap)
+        XCTAssertEqual(r.selected.count, 5)
+        XCTAssertEqual(r.selected.reduce(0) { $0 + $1.amount }, 5)
+        XCTAssertEqual(r.inputFee, 0)
+        // Distinct, real input proofs.
+        let cs = r.selected.map { $0.C }
+        XCTAssertEqual(Set(cs).count, 5)
+        let inputCs = Set(proofs.map { $0.C })
+        XCTAssertTrue(cs.allSatisfy { inputCs.contains($0) })
+    }
+
+    func testDirectNoExactSubsetFallsToMintTransaction() throws {
+        let m = mint([ks("A", ppk: 0)])
+        let proofs = [proof(2, "A", id: 1), proof(4, "A", id: 2)]   // no subset sums to 3
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: 3, mint: m,
+                                            unit: "sat", purpose: .tokenTransferUnlocked)
+        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertGreaterThanOrEqual(r.netAmount, 3)
+    }
+
+    func testMeltTargetIncludesFeeReserve() throws {
+        // Caller passes target = quote.amount + feeReserve. Selection guarantees
+        // net >= target, i.e. sum >= amount + feeReserve + inputFee.
+        let m = mint([ks("A", ppk: 100)])
+        let proofs = (0..<8).map { proof(8, "A", id: $0) }   // 64 sat total
+        let amount = 40, feeReserve = 5
+        let r = try CashuSwift.selectProofs(proofs, targetAmount: amount + feeReserve, mint: m,
+                                            unit: "sat", purpose: .melt)
+        XCTAssertGreaterThanOrEqual(r.netAmount, amount + feeReserve)
+        XCTAssertEqual(r.inputFee, ceilFee(r.selected.count * 100))
+    }
+
+    // MARK: Brute-force property tests
+
+    private let keysetPool: [CashuSwift.Keyset] = [
+        ks("K0", ppk: 0, active: true),
+        ks("K1", ppk: 1, active: true),
+        ks("K2", ppk: 100, active: true),
+        ks("K3", ppk: 999, active: false),
+        ks("K4", ppk: 1000, active: true),
+        ks("K5", ppk: 1001, active: false),
+    ]
+    private let amountPool = [1, 2, 3, 4, 5, 7, 8, 16, 32, 64]
+
+    func testBruteForceFeeAware() throws {
+        let m = mint(keysetPool)
+        var rng = SeededRNG(seed: 0xCA54_F00D)
+        for _ in 0..<1500 {
+            let n = Int.random(in: 1...12, using: &rng)
+            var proofs: [CashuSwift.Proof] = []
+            var oracle: [(amount: Int, ppk: Int)] = []
+            for i in 0..<n {
+                let k = keysetPool[Int.random(in: 0..<keysetPool.count, using: &rng)]
+                let amount = amountPool[Int.random(in: 0..<amountPool.count, using: &rng)]
+                proofs.append(proof(amount, k.keysetID, id: i))
+                oracle.append((amount, k.inputFeePPK))
+            }
+            let allNet = oracle.reduce(0) { $0 + $1.amount } - ceilFee(oracle.reduce(0) { $0 + $1.ppk })
+            guard allNet >= 1 else { continue }
+            let target = Int.random(in: 1...(allNet + 3), using: &rng)   // sometimes infeasible
+
+            let expected = bruteForceMint(oracle, target: target)
+            do {
+                let r = try CashuSwift.selectProofs(proofs, targetAmount: target, mint: m,
+                                                    unit: "sat", purpose: .swap)
+                guard let expected else {
+                    return XCTFail("DP succeeded but brute force found no feasible subset (target \(target))")
+                }
+                let raw = r.selected.reduce(0) { $0 + $1.amount }
+                XCTAssertEqual(r.inputFee, expected.fee, "fee mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(r.changeAmount, expected.change, "change mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(r.selected.count, expected.count, "count mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(raw, expected.raw, "raw mismatch, target \(target), proofs \(oracle)")
+                XCTAssertEqual(r.netAmount, raw - r.inputFee)
+                XCTAssertGreaterThanOrEqual(r.netAmount, target)
+                XCTAssertEqual(Set(r.selected.map { $0.C }).count, r.selected.count, "duplicate proofs selected")
+            } catch CashuSwift.ProofSelectionError.insufficientFunds {
+                XCTAssertNil(expected, "DP reported insufficient but brute force found a subset (target \(target), proofs \(oracle))")
+            }
+        }
+    }
+
+    func testBruteForceDirectExact() throws {
+        let m = mint(keysetPool)
+        var rng = SeededRNG(seed: 0x1234_5678)
+        for _ in 0..<1500 {
+            let n = Int.random(in: 1...12, using: &rng)
+            var proofs: [CashuSwift.Proof] = []
+            var oracle: [(amount: Int, ppk: Int)] = []
+            for i in 0..<n {
+                let k = keysetPool[Int.random(in: 0..<keysetPool.count, using: &rng)]
+                let amount = amountPool[Int.random(in: 0..<amountPool.count, using: &rng)]
+                proofs.append(proof(amount, k.keysetID, id: i))
+                oracle.append((amount, k.inputFeePPK))
+            }
+            // Force a target that has at least one exact subset by summing a random subset.
+            let mask = Int.random(in: 1..<(1 << n), using: &rng)
+            var target = 0
+            for i in 0..<n where mask & (1 << i) != 0 { target += oracle[i].amount }
+
+            let expected = bruteForceExact(oracle, target: target)!   // the chosen subset guarantees one
+            let r = try CashuSwift.selectProofs(proofs, targetAmount: target, mint: m,
+                                                unit: "sat", purpose: .tokenTransferUnlocked)
+            XCTAssertEqual(r.kind, .directToken, "exact subset exists but DP didn't pick a direct send (target \(target), proofs \(oracle))")
+            XCTAssertEqual(r.inputFee, 0)
+            let raw = r.selected.reduce(0) { $0 + $1.amount }
+            XCTAssertEqual(raw, target)
+            // Optimal on (count, ppk).
+            let ppk = r.selected.reduce(0) { partial, p in
+                partial + (keysetPool.first { $0.keysetID == p.keysetID }?.inputFeePPK ?? 0)
+            }
+            XCTAssertEqual(r.selected.count, expected.count, "count not minimal (target \(target), proofs \(oracle))")
+            XCTAssertEqual(ppk, expected.ppk, "ppk not minimal among min-count subsets (target \(target), proofs \(oracle))")
+            XCTAssertEqual(Set(r.selected.map { $0.C }).count, r.selected.count)
+        }
+    }
+}

--- a/Tests/cashu-swiftTests/ProofSelectionTests.swift
+++ b/Tests/cashu-swiftTests/ProofSelectionTests.swift
@@ -149,7 +149,7 @@ final class ProofSelectionTests: XCTestCase {
         let proofs = [proof(100, "HI", id: 1), proof(101, "LO", id: 2)]
         let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
                                             unit: "sat", purpose: .swap)
-        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertEqual(r.kind, .swap)
         XCTAssertEqual(r.inputFee, 0)
         XCTAssertEqual(r.selected.count, 1)
         XCTAssertEqual(r.selected.first?.amount, 101)
@@ -181,12 +181,12 @@ final class ProofSelectionTests: XCTestCase {
         XCTAssertEqual(r.selected.first?.keysetID, "A")
     }
 
-    /// #7 — for mint transactions, inactive keysets win an otherwise-exact tie.
+    /// #7 — for swaps, inactive keysets win an otherwise-exact tie.
     func testInactiveKeysetPreferredForMint() throws {
         let m = mint([ks("ACT", ppk: 0, active: true), ks("INACT", ppk: 0, active: false)])
         let proofs = [proof(100, "ACT", id: 1), proof(100, "INACT", id: 2)]
         var policy = CashuSwift.ProofSelectionPolicy.default
-        policy.preferInactiveKeysetsForMintTransactions = true
+        policy.preferInactiveKeysetsForSwaps = true
         let r = try CashuSwift.selectProofs(proofs, targetAmount: 100, mint: m,
                                             unit: "sat", purpose: .swap, policy: policy)
         XCTAssertEqual(r.selected.count, 1)
@@ -336,12 +336,12 @@ final class ProofSelectionTests: XCTestCase {
         XCTAssertTrue(cs.allSatisfy { inputCs.contains($0) })
     }
 
-    func testDirectNoExactSubsetFallsToMintTransaction() throws {
+    func testDirectNoExactSubsetFallsToSwap() throws {
         let m = mint([ks("A", ppk: 0)])
         let proofs = [proof(2, "A", id: 1), proof(4, "A", id: 2)]   // no subset sums to 3
         let r = try CashuSwift.selectProofs(proofs, targetAmount: 3, mint: m,
                                             unit: "sat", purpose: .tokenTransferUnlocked)
-        XCTAssertEqual(r.kind, .mintTransaction)
+        XCTAssertEqual(r.kind, .swap)
         XCTAssertGreaterThanOrEqual(r.netAmount, 3)
     }
 


### PR DESCRIPTION
Stacked on #24 (`proof-selection`). Base is `proof-selection` so the diff is just this feature; GitHub will retarget it to `main` once #24 merges.

## Why

A token is just a bundle of proofs, so an *offline* (unlocked) send of amount `X` is only possible when the wallet already holds a subset of proofs summing to exactly `X` — making change needs a swap round-trip. The lever is the wallet's **denomination shape**: hold ~`N` proofs of each power-of-two denomination (default `N=3`) so exact subsets exist for most amounts, repeatedly.

This PR is **library-only and fully opt-in** — every new parameter defaults to `nil`/off, so existing behaviour is byte-identical. The wallet owns *policy* (the value of `N`, when to rebalance) and *proof-state*; the library owns the math.

## What's added

- **Planning primitives** (`DistributionPlanning.swift`): `DenominationTarget`, `idealDistribution(balance:)`, `preferredDistribution(forAmount:retained:)` (for receive/mint, which don't select their own proofs), and `denominationGap` — which reports **deficits and surplus** so a wallet can decide when a fee-incurring consolidation swap is worthwhile.
- **Target-aware selection**: `selectProofs(…, denominationTarget:)` shapes `changeOutputAmounts` to fill the wallet's denomination deficits instead of a plain base-2 split. **Input selection is provably unchanged** (the DP is untouched).
- **Operation hooks**: `send(preferredKeepDistribution:)`, `receive(preferredReturnDistribution:)`, and `swap(amount: nil)` now shapes the *whole* returned pool (it was previously ignored) — enabling receive- and consolidation-time rebalancing through one path.
- **Offline primitive**: synchronous, network-free `offlineToken(for:mint:memo:)` (the offline-send builder) plus the `canSendOffline(…)` predicate.

## "Both directions" — design note

An output split can only *add* coins, so it fills deficits but can't remove a surplus. I initially added a "drain surplus" *input-selection* tie-breaker, then reverted it: for power-of-two coins the selector's optimum is essentially unique in `(fee, change, count, amount)`, so it almost never fires while widening the Stage-2 Pareto frontier (a real perf cost). The surplus direction is instead handled by a **wallet-initiated consolidation swap** — the wallet spots surplus via `denominationGap` and reshapes with `idealDistribution`. Proven end-to-end (`testConsolidationSwapReachesIdealShape`: whole-balance swap → zero gap).

## Terminology

Renamed the selector's "mint transaction" wording to **swap** / **fee-aware** (`ProofSelectionKind.mintTransaction → .swap`, `preferInactiveKeysetsForMintTransactions → preferInactiveKeysetsForSwaps`, private `mint* → feeAware*`). Minting (NUT-04) consumes no existing proofs and isn't reachable through `selectProofs`; the path being selected for is a swap/melt.

## Tests

New: `DistributionPlanningTests` (37), `ProofSelectionTargetTests` (8), `OfflineDistributionHooksTests` (8), `OfflineTokenTests` (10). Network-free unit/property tests plus FakeWallet-mint integration (which skips when unreachable). All suites green, including existing ProofSelection/PaymentRequest regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
